### PR TITLE
fix(gleam_test): actually run test assertions

### DIFF
--- a/gleam/private/gleam_test.bzl
+++ b/gleam/private/gleam_test.bzl
@@ -101,6 +101,19 @@ def _gleam_test_impl(ctx):
 
     pa_flags = " ".join(pa_parts)
 
+    # gleeunit.main() discovers which compiled modules to run as tests by scanning a
+    # "test" directory *relative to the process's current working directory* at runtime
+    # (see gleeunit_ffi.erl's find_files/2) -- it does not accept an explicit module list.
+    # Bazel's test-setup.sh already chdirs into $TEST_SRCDIR/$TEST_WORKSPACE before running
+    # this script, so for a package declared at the workspace root that's exactly where its
+    # "test" directory's runfiles land. For a package nested under a subdirectory (e.g.
+    # "outer/inner"), we must additionally cd into that subdirectory ourselves, or gleeunit
+    # will silently find no "test" directory, discover zero test modules, and report success
+    # having run nothing at all.
+    cd_cmd = ""
+    if src_dir:
+        cd_cmd = 'cd "{}" && '.format(src_dir)
+
     ctx.actions.write(
         output = test_runner_script,
         is_executable = True,
@@ -108,16 +121,24 @@ def _gleam_test_impl(ctx):
 # Test runner for Gleam tests: {label}
 set -e
 
-exec "{erl_path}" {pa_flags} -noshell -s gleeunit main -s init stop
+{cd_cmd}exec "{erl_path}" {pa_flags} -noshell -s gleeunit main -s init stop
 """.format(
             label = ctx.label.name,
+            cd_cmd = cd_cmd,
             erl_path = erl_path,
             pa_flags = pa_flags,
         ),
     )
 
-    # Runfiles: test runner needs the compiled test dir + all dep dirs.
-    runfiles_files = [compiled_dir] + all_dep_dirs.to_list()
+    # Runfiles: test runner needs the compiled test dir, all dep dirs, the raw test_srcs
+    # (so gleeunit's runtime directory scan of "test/" actually finds something to run --
+    # see above), and any declared runtime data.
+    runfiles_files = (
+        [compiled_dir] +
+        all_dep_dirs.to_list() +
+        list(ctx.files.test_srcs) +
+        list(ctx.files.data)
+    )
 
     return [
         DefaultInfo(


### PR DESCRIPTION
## Summary

First PR in a stack working through the rest of the Gleam rules review. This one takes priority over everything else planned (JUnit XML output, `--test_filter`, sharding, etc.) because it turned out those would all be built on top of a rule that doesn't actually run any tests.

- `gleeunit.main()` discovers which compiled modules to treat as tests by scanning a `test` directory *relative to the process's current working directory* at runtime (see `gleeunit_ffi.erl`'s `find_files/2`) — it does not accept an explicit module list.
- Bazel's `test-setup.sh` `cd`s into `$TEST_SRCDIR/$TEST_WORKSPACE` before running any test binary, but `gleam_test`'s runfiles only ever included the *compiled* BEAM directories, never the raw `test/*.gleam` sources, and the rule never `cd`'d into a nested package's own directory.
- Net effect: gleeunit's runtime scan found no `test` directory, discovered zero test modules, and `eunit:test([], ...)` trivially reported success having run nothing at all.

**Empirically verified**, not just reasoned about: opened a throwaway PR (#69, now closed, not merged) with a deliberately wrong assertion in `examples/smoke/test/my_app_test.gleam`.
1. Broken assertion + current main → `Test (Bazel 8.x/9.x)` reported **PASS**. Confirms the bug.
2. Applied this fix on top of the same broken assertion → reported a genuine **FAIL** with a real eunit panic (`"Hello from my_app!" should equal "THIS ASSERTION IS DELIBERATELY WRONG..."`, `0 passed, 1 failures`).
3. Reverted the assertion to correct, same fix → genuine **PASS**.

## Fix

- Ship `test_srcs` (and `data`) as runfiles, not just the compiled directories.
- `cd` into the package's own directory (relative to the workspace root) before invoking `erl`, so gleeunit's `test` directory scan finds something whether the package is declared at the workspace root (`examples/smoke`, `examples/hello_world`) or nested under a subdirectory (`examples/nested_smoke/outer/inner`).

## Test plan

- [x] Empirically verified via throwaway PR #69 (see above) — false-pass reproduced, fix turns it into a real fail, correct assertion produces a real pass.
- [x] `python3 -c "import ast; ast.parse(...)"` sanity check on the modified `.bzl` file (no Bazel available in this sandbox for a full build).
- [ ] CI on this PR: should show `Test (Bazel 8.x/9.x)` passing for real against the existing (correct) example tests in `examples/smoke`, `examples/hello_world`, and `examples/nested_smoke`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_