### PR TITLE
TEMP/DO NOT MERGE: verify gleam_release runfiles resolution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,17 @@ jobs:
           else
             bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
           fi
+      - name: TEMP DIAGNOSTIC - gleam_release verification
+        working-directory: examples/smoke
+        run: |
+          echo "=== bazel build //:my_app_release ==="
+          bazel build --enable_bzlmod --noenable_workspace //:my_app_release
+          echo "=== direct invocation (exercises \$0.runfiles fallback) ==="
+          ./bazel-bin/my_app_release
+          echo "=== bazel run (exercises RUNFILES_DIR) ==="
+          bazel run --enable_bzlmod --noenable_workspace //:my_app_release
+          echo "=== gleam.toml present in runfiles? (proves transitive_data flows through) ==="
+          find bazel-bin/my_app_release.runfiles -name "gleam.toml" || echo "NOT FOUND"
       - name: Run Bazel Tests - examples/nested_smoke Directory
         working-directory: examples/nested_smoke
         run: |

--- a/examples/smoke/BUILD.bazel
+++ b/examples/smoke/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_gleam//gleam:defs.bzl", "gleam_package")
+load("@rules_gleam//gleam:defs.bzl", "gleam_package", "gleam_release")
 
 # gleam_package expands to:
 #  - a gleam_library "my_app_lib" (since entry_module is set, the library is not named
@@ -14,4 +14,14 @@ gleam_package(
     test_deps = ["@gleam_packages//:gleeunit"],
     test_srcs = glob(["test/**/*.gleam"]),
     deps = ["@gleam_packages//:gleam_stdlib"],
+)
+
+# Same entry point, packaged as a runfiles-tree binary instead of a single-file escript.
+# my_app_lib's data (gleam.toml, from gleam_package above) flows through transitively,
+# proving gleam_release actually ships declared runtime data rather than only the
+# compiled BEAM directories.
+gleam_release(
+    name = "my_app_release",
+    dep = ":my_app_lib",
+    entry_module = "main",
 )

--- a/gleam/BUILD.bazel
+++ b/gleam/BUILD.bazel
@@ -39,6 +39,7 @@ bzl_library(
     deps = [
         "//gleam/private:gleam_binary",
         "//gleam/private:gleam_library",
+        "//gleam/private:gleam_release",
         "//gleam/private:gleam_test",
         "//gleam/private:package_name_check",
     ],

--- a/gleam/defs.bzl
+++ b/gleam/defs.bzl
@@ -2,11 +2,13 @@
 
 load("//gleam/private:gleam_binary.bzl", _gleam_binary_rule = "gleam_binary")
 load("//gleam/private:gleam_library.bzl", _GleamPackageInfo = "GleamPackageInfo", _gleam_library_rule = "gleam_library")
+load("//gleam/private:gleam_release.bzl", _gleam_release_rule = "gleam_release")
 load("//gleam/private:gleam_test.bzl", _gleam_test_rule = "gleam_test")
 load("//gleam/private:package_name_check.bzl", "gleam_package_name_check")
 
 gleam_library = _gleam_library_rule
 gleam_binary = _gleam_binary_rule
+gleam_release = _gleam_release_rule
 gleam_test = _gleam_test_rule
 GleamPackageInfo = _GleamPackageInfo
 

--- a/gleam/private/BUILD.bazel
+++ b/gleam/private/BUILD.bazel
@@ -20,6 +20,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "gleam_release",
+    srcs = ["gleam_release.bzl"],
+    visibility = ["//gleam:__subpackages__"],
+    deps = [":gleam_library"],
+)
+
+bzl_library(
     name = "gleam_test",
     srcs = ["gleam_test.bzl"],
     visibility = ["//gleam:__subpackages__"],

--- a/gleam/private/gleam_library.bzl
+++ b/gleam/private/gleam_library.bzl
@@ -12,6 +12,7 @@ GleamPackageInfo = provider(
         "compiled_dir": "TreeArtifact (named after the package) containing ebin/ with compiled BEAM files.",
         "package_name": "Name of the Gleam package.",
         "transitive_compiled_dirs": "Depset of all transitive compiled TreeArtifacts (including this package's own).",
+        "transitive_data": "Depset of all transitive runtime data Files (this package's own `data` plus all deps', transitively).",
     },
 )
 
@@ -29,16 +30,24 @@ def _gleam_library_impl(ctx):
     # Collect dependency info.
     dep_infos = []
     transitive_dep_sets = []
+    transitive_data_sets = []
     for dep in ctx.attr.deps:
         if GleamPackageInfo in dep:
             dep_info = dep[GleamPackageInfo]
             dep_infos.append(dep_info)
             transitive_dep_sets.append(dep_info.transitive_compiled_dirs)
+            transitive_data_sets.append(dep_info.transitive_data)
 
     # Build the transitive depset (includes this package's own output).
     transitive_compiled_dirs = depset(
         direct = [compiled_dir],
         transitive = transitive_dep_sets,
+    )
+
+    # Build the transitive data depset (includes this package's own `data`).
+    transitive_data = depset(
+        direct = ctx.files.data,
+        transitive = transitive_data_sets,
     )
 
     # Prepare inputs: source files + all transitive compiled dirs.
@@ -94,6 +103,7 @@ def _gleam_library_impl(ctx):
             compiled_dir = compiled_dir,
             package_name = package_name,
             transitive_compiled_dirs = transitive_compiled_dirs,
+            transitive_data = transitive_data,
         ),
     ]
 

--- a/gleam/private/gleam_release.bzl
+++ b/gleam/private/gleam_release.bzl
@@ -1,0 +1,118 @@
+"""Implementation of the gleam_release rule.
+
+Packages a gleam_library and its transitive deps as a runfiles-tree binary (a small launcher
+script plus the compiled BEAM directories and any declared runtime `data`), rather than a
+single self-contained escript.
+
+This is the right shape for services that need config files, templates, certs, or other
+runtime data available alongside the compiled code (see gleam_binary for the single-file
+escript alternative, better suited to portable CLI tools that don't need bundled data).
+"""
+
+load("//gleam/private:gleam_library.bzl", "GleamPackageInfo")
+
+def _gleam_release_impl(ctx):
+    gleam_toolchain_info = ctx.toolchains["//gleam:toolchain_type"]
+    erlang_toolchain = gleam_toolchain_info.erlang_toolchain
+
+    dep_info = ctx.attr.dep[GleamPackageInfo]
+    entry_module = ctx.attr.entry_module
+    entry_function = ctx.attr.entry_function
+
+    all_compiled_dirs = dep_info.transitive_compiled_dirs.to_list()
+    all_data = dep_info.transitive_data.to_list()
+
+    erl_path = "erl"
+    if hasattr(erlang_toolchain, "erl_path_str") and erlang_toolchain.erl_path_str:
+        erl_path = erlang_toolchain.erl_path_str
+
+    launcher = ctx.actions.declare_file(ctx.label.name)
+
+    # At runtime, paths are relative to this launcher's own runfiles root, joined with the
+    # workspace name (matching how gleam_test locates -pa paths under $TEST_SRCDIR/$WORKSPACE).
+    ws_name = ctx.workspace_name
+    pa_parts = []
+    for compiled_dir in all_compiled_dirs:
+        pa_parts.append('-pa "$RF/{ws}/{path}/ebin"'.format(ws = ws_name, path = compiled_dir.short_path))
+    pa_flags = " ".join(pa_parts)
+
+    ctx.actions.write(
+        output = launcher,
+        is_executable = True,
+        content = """#!/bin/bash
+# Launcher for Gleam release: {label}
+set -euo pipefail
+
+# Resolve this binary's own runfiles root, whether invoked via `bazel run`, run directly
+# after `bazel build` (Bazel places a "<binary>.runfiles" directory next to the output),
+# or as a dependency of another runfiles-aware binary. This only covers the Unix layout
+# (symlinked runfiles tree); Windows is not supported here.
+if [[ -n "${{RUNFILES_DIR:-}}" && -d "${{RUNFILES_DIR:-}}" ]]; then
+  RF="$RUNFILES_DIR"
+elif [[ -d "$0.runfiles" ]]; then
+  RF="$0.runfiles"
+elif [[ -d "${{BASH_SOURCE[0]}}.runfiles" ]]; then
+  RF="${{BASH_SOURCE[0]}}.runfiles"
+else
+  echo "ERROR: could not locate the runfiles directory for {label}." >&2
+  exit 1
+fi
+
+exec "{erl_path}" {pa_flags} -noshell -s {entry_module} {entry_function} -s init stop
+""".format(
+            label = ctx.label.name,
+            erl_path = erl_path,
+            pa_flags = pa_flags,
+            entry_module = entry_module,
+            entry_function = entry_function,
+        ),
+    )
+
+    # Runfiles: all transitive compiled dirs (for -pa) plus all transitive runtime data, so
+    # code can read data files at paths relative to its own package -- see the "data" attr
+    # on gleam_library for how those paths are laid out.
+    runfiles_files = all_compiled_dirs + all_data
+
+    return [
+        DefaultInfo(
+            executable = launcher,
+            files = depset([launcher]),
+            runfiles = ctx.runfiles(files = runfiles_files),
+        ),
+    ]
+
+gleam_release = rule(
+    implementation = _gleam_release_impl,
+    attrs = {
+        "dep": attr.label(
+            doc = "The gleam_library target containing the entry point module.",
+            providers = [GleamPackageInfo],
+            mandatory = True,
+        ),
+        "entry_module": attr.string(
+            doc = "The Erlang module name to call at startup (e.g. 'main').",
+            mandatory = True,
+        ),
+        "entry_function": attr.string(
+            doc = "The function to call in the entry module.",
+            default = "main",
+        ),
+    },
+    toolchains = ["//gleam:toolchain_type"],
+    executable = True,
+    doc = """\
+Packages a `gleam_library` and its transitive deps as a runfiles-tree binary: a small
+launcher script plus the compiled BEAM directories and any declared runtime `data`
+(config files, templates, certs, etc.), reachable at runtime under the launcher's own
+runfiles directory.
+
+Unlike `gleam_binary`, this does not produce a single self-contained escript -- the
+result is a launcher script that must be run alongside its `.runfiles` directory (as
+`bazel run` does automatically, and as a `bazel build`-produced binary does when invoked
+directly). This is the tradeoff for being able to ship `data` at all: escript archives
+don't compose with Bazel's runfiles model.
+
+Does not attempt to start the package as an OTP application (no `application:ensure_all_started`
+call) -- call it yourself from `entry_module` if your package needs it.
+""",
+)


### PR DESCRIPTION
Throwaway PR to empirically verify the new `gleam_release` rule's runfiles resolution (both the `bazel run` RUNFILES_DIR path and the direct-invocation `$0.runfiles` fallback path), and that `transitive_data` actually ships declared data files. Will close without merging once verified.

---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_