### PR TITLE
TEMP/DO NOT MERGE: verify web_service example

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,15 @@ jobs:
           else
             bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
           fi
+      - name: Run Bazel Tests - examples/web_service Directory
+        working-directory: examples/web_service
+        run: |
+          echo "Running tests in examples/web_service directory with bzlmod=${{ matrix.bzlmod-enabled }}"
+          if ${{ matrix.bzlmod-enabled }}; then
+            bazel test --enable_bzlmod --noenable_workspace --test_output=errors //...
+          else
+            bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
+          fi
       - name: Run Bazel Build - examples/hello_world Directory
         working-directory: examples/hello_world
         run: |

--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ git_override(
 
 ## Usage
 
-See a basic example [here](examples/smoke)
+See a basic example [here](examples/smoke). For a runnable HTTP service with a real
+end-to-end test, see [examples/web_service](examples/web_service).

--- a/examples/web_service/BUILD.bazel
+++ b/examples/web_service/BUILD.bazel
@@ -14,16 +14,17 @@ _DEPS = [
     "@gleam_packages//:mist",
 ]
 
-# gleam_package expands to a gleam_library "web_service_lib" (entry_module is not set
-# here -- the runnable target below is a gleam_release, not a gleam_binary escript) and a
-# gleam_test "web_service_test" for the pure-function unit test.
+# gleam_package expands to a gleam_library "web_service" (entry_module is not set here --
+# the runnable target below is a gleam_release, not a gleam_binary escript, so the library
+# takes the bare target name, matching gleam.toml's package name) and a gleam_test
+# "web_service_test" for the pure-function unit test.
 gleam_package(
-    name = "web_service_lib",
+    name = "web_service",
     srcs = glob(["src/**/*.gleam"]),
     gleam_toml = "gleam.toml",
-    deps = _DEPS,
     test_deps = ["@gleam_packages//:gleeunit"],
     test_srcs = glob(["test/**/*.gleam"]),
+    deps = _DEPS,
 )
 
 # Packaged as a runfiles-tree binary (not a single-file escript): a real web service
@@ -31,7 +32,7 @@ gleam_package(
 # and this shape is what composes with `data` and with container-image rules.
 gleam_release(
     name = "web_service_bin",
-    dep = ":web_service_lib",
+    dep = ":web_service",
     entry_module = "web_service",
 )
 

--- a/examples/web_service/BUILD.bazel
+++ b/examples/web_service/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@rules_gleam//gleam:defs.bzl", "gleam_package", "gleam_release")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+_DEPS = [
+    "@gleam_packages//:exception",
+    "@gleam_packages//:gleam_erlang",
+    "@gleam_packages//:gleam_http",
+    "@gleam_packages//:gleam_otp",
+    "@gleam_packages//:gleam_stdlib",
+    "@gleam_packages//:glisten",
+    "@gleam_packages//:gramps",
+    "@gleam_packages//:hpack_erl",
+    "@gleam_packages//:logging",
+    "@gleam_packages//:mist",
+]
+
+# gleam_package expands to a gleam_library "web_service_lib" (entry_module is not set
+# here -- the runnable target below is a gleam_release, not a gleam_binary escript) and a
+# gleam_test "web_service_test" for the pure-function unit test.
+gleam_package(
+    name = "web_service_lib",
+    srcs = glob(["src/**/*.gleam"]),
+    gleam_toml = "gleam.toml",
+    deps = _DEPS,
+    test_deps = ["@gleam_packages//:gleeunit"],
+    test_srcs = glob(["test/**/*.gleam"]),
+)
+
+# Packaged as a runfiles-tree binary (not a single-file escript): a real web service
+# doesn't need portability to a machine without Bazel/runfiles the way a CLI tool might,
+# and this shape is what composes with `data` and with container-image rules.
+gleam_release(
+    name = "web_service_bin",
+    dep = ":web_service_lib",
+    entry_module = "web_service",
+)
+
+# An end-to-end/acceptance test: starts the real web_service_bin binary and makes a real
+# HTTP request against it. See test/web_service_test.gleam for the unit-test level.
+sh_test(
+    name = "web_service_e2e_test",
+    srcs = ["e2e_test.sh"],
+    data = [":web_service_bin"],
+    tags = ["requires-network"],
+)

--- a/examples/web_service/MODULE.bazel
+++ b/examples/web_service/MODULE.bazel
@@ -1,0 +1,105 @@
+bazel_dep(name = "muchq_rules_gleam", version = "0.0.1", repo_name = "rules_gleam")
+local_path_override(
+    module_name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+
+gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
+gleam.toolchain(version = "1.14.0")
+
+# mist (a Gleam HTTP server) and its full transitive Hex dependency graph, hand-resolved
+# and hand-checksummed (there's no Hex lockfile-driven dependency resolution yet -- see
+# the project README/CONTRIBUTING for that as a known follow-up). Versions were chosen as
+# the latest stable release of each package as of writing, cross-checked so that every
+# package's declared requirement on every other package in this graph is satisfied.
+gleam.hex_package(
+    name = "gleam_stdlib",
+    sha256 = "1f543afba5d33da493e6087f4e4c4f20d899411343512686c98a8abb2963cf22",
+    version = "1.0.3",
+    deps = [],
+)
+gleam.hex_package(
+    name = "exception",
+    sha256 = "6bdea95248093599391c3b5df1835c5c6a86c353c2f99ce539b450e3432fe117",
+    version = "2.1.1",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "gleam_crypto",
+    sha256 = "2de9e4ef53cf6fee049d4f765731f7178f7a11aefae00eee63bf7536b354ad3f",
+    version = "1.6.0",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "gleam_erlang",
+    sha256 = "1124ad3aa21143e5af0fc5cf3d9529f6db8ca03e43a55711b60b6b7b3874375c",
+    version = "1.3.0",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "gleam_http",
+    sha256 = "82ea6a717c842456188c190afb372665ea56ce13d8559bf3b1dd9e40f619ee0c",
+    version = "4.3.0",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "gleam_otp",
+    sha256 = "ba6a294e295e428ec1562dc1c11ea7530dcb981e8359134beabc8493b7b2258e",
+    version = "1.2.0",
+    deps = ["gleam_erlang", "gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "logging",
+    sha256 = "bc5f18ce5dd9686100229fe5409bdc3dd5c46d5a7df2f804ad2d8f0dd6c5060e",
+    version = "1.5.0",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "glisten",
+    sha256 = "7795aa50830656f3a0316a6b26595f893c83272da901b3405e31339caa31a10b",
+    version = "9.0.1",
+    deps = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"],
+)
+gleam.hex_package(
+    name = "gramps",
+    sha256 = "d55636072dee173f6586a5679d3c02ec7a0de3f8646b78c351b72908ff223df7",
+    version = "6.0.1",
+    deps = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "hpack_erl",
+    sha256 = "d6137d7079169d8c485c6962dfe261af5b9ef60fbc557344511c1e65e3d95fb0",
+    version = "0.3.0",
+    deps = [],
+)
+gleam.hex_package(
+    name = "mist",
+    sha256 = "1b07f321d5fa0cb162d81496f2de96aeb6ef8980f4f38230a4cc3f849497e020",
+    version = "6.0.3",
+    deps = [
+        "exception",
+        "gleam_erlang",
+        "gleam_http",
+        "gleam_otp",
+        "gleam_stdlib",
+        "glisten",
+        "gramps",
+        "hpack_erl",
+        "logging",
+    ],
+)
+gleam.hex_package(
+    name = "gleeunit",
+    sha256 = "ec31aba74256aea531edf8169931d775bbb384fed0a8a1bdc4dd9354e3e21826",
+    version = "1.11.0",
+    deps = ["gleam_stdlib"],
+)
+use_repo(gleam, "gleam_packages", "gleam_toolchains", "local_config_erlang")
+
+register_toolchains("@gleam_toolchains//:all")
+
+register_toolchains("@local_config_erlang//:erlang_toolchain_definition")

--- a/examples/web_service/MODULE.bazel
+++ b/examples/web_service/MODULE.bazel
@@ -50,7 +50,10 @@ gleam.hex_package(
     name = "gleam_otp",
     sha256 = "ba6a294e295e428ec1562dc1c11ea7530dcb981e8359134beabc8493b7b2258e",
     version = "1.2.0",
-    deps = ["gleam_erlang", "gleam_stdlib"],
+    deps = [
+        "gleam_erlang",
+        "gleam_stdlib",
+    ],
 )
 gleam.hex_package(
     name = "logging",
@@ -62,13 +65,23 @@ gleam.hex_package(
     name = "glisten",
     sha256 = "7795aa50830656f3a0316a6b26595f893c83272da901b3405e31339caa31a10b",
     version = "9.0.1",
-    deps = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"],
+    deps = [
+        "gleam_erlang",
+        "gleam_otp",
+        "gleam_stdlib",
+        "logging",
+    ],
 )
 gleam.hex_package(
     name = "gramps",
     sha256 = "d55636072dee173f6586a5679d3c02ec7a0de3f8646b78c351b72908ff223df7",
     version = "6.0.1",
-    deps = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"],
+    deps = [
+        "gleam_crypto",
+        "gleam_erlang",
+        "gleam_http",
+        "gleam_stdlib",
+    ],
 )
 gleam.hex_package(
     name = "hpack_erl",

--- a/examples/web_service/WORKSPACE.bazel
+++ b/examples/web_service/WORKSPACE.bazel
@@ -1,0 +1,19 @@
+# Override http_archive for local testing
+local_repository(
+    name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+#---SNIP--- Below here is re-used in the workspace snippet published on releases
+
+######################
+# rules_gleam setup #
+######################
+# Fetches the rules_gleam dependencies.
+# If you want to have a different version of some dependency,
+# you should fetch it *before* calling this.
+# Alternatively, you can skip calling this function, so long as you've
+# already fetched all the dependencies.
+load("@muchq_rules_gleam//gleam:repositories.bzl", "rules_gleam_dependencies")
+
+rules_gleam_dependencies()

--- a/examples/web_service/WORKSPACE.bzlmod
+++ b/examples/web_service/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# When --enable_bzlmod is set, this file replaces WORKSPACE.bazel.
+# Dependencies then come from MODULE.bazel instead.

--- a/examples/web_service/e2e_test.sh
+++ b/examples/web_service/e2e_test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# End-to-end test for the web_service example: starts the real gleam_release binary as a
+# subprocess, makes a real HTTP request against it, and checks the response -- as opposed
+# to web_service_test.gleam, which only unit-tests a pure helper function.
+#
+# Demonstrates the "wrap a gleam_release/gleam_binary executable in a native Bazel test
+# rule" pattern for black-box acceptance testing: no custom Gleam or Erlang test code is
+# needed here, just the compiled binary (as a `data` dependency) plus a normal shell test.
+set -euo pipefail
+
+PORT=34817
+URL="http://localhost:${PORT}/"
+
+# web_service_bin is itself runfiles-aware (see gleam_release's docstring): it looks for
+# RUNFILES_DIR first, before falling back to locating its own ".runfiles" directory. Since
+# this test's own runfiles tree (set up by Bazel's test-setup.sh, rooted at
+# $TEST_SRCDIR/$TEST_WORKSPACE) already contains web_service_bin's compiled dependencies
+# merged in as a `data` dependency, we can just point it there directly.
+export RUNFILES_DIR="$TEST_SRCDIR"
+
+./web_service_bin &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+
+READY=""
+for _ in $(seq 1 40); do
+  if RESPONSE="$(curl -sf --max-time 1 "$URL")"; then
+    READY=1
+    break
+  fi
+  sleep 0.25
+done
+
+if [[ -z "$READY" ]]; then
+  echo "FAIL: server never became ready on $URL" >&2
+  exit 1
+fi
+
+EXPECTED="Hello from web_service!"
+if [[ "$RESPONSE" != "$EXPECTED" ]]; then
+  echo "FAIL: expected response body '$EXPECTED', got '$RESPONSE'" >&2
+  exit 1
+fi
+
+echo "PASS: got expected response body: $RESPONSE"

--- a/examples/web_service/gleam.toml
+++ b/examples/web_service/gleam.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 
 [dependencies]
 gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_http = ">= 4.0.0 and < 5.0.0"
 mist = ">= 6.0.0 and < 7.0.0"
 
 [dev-dependencies]

--- a/examples/web_service/gleam.toml
+++ b/examples/web_service/gleam.toml
@@ -1,0 +1,9 @@
+name = "web_service"
+version = "0.1.0"
+
+[dependencies]
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+mist = ">= 6.0.0 and < 7.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.11.0 and < 2.0.0"

--- a/examples/web_service/src/web_service.gleam
+++ b/examples/web_service/src/web_service.gleam
@@ -1,0 +1,30 @@
+import gleam/bytes_tree
+import gleam/erlang/process
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
+import mist.{type Connection, type ResponseData}
+
+/// Fixed for simplicity in this example. A real service should prefer binding to
+/// port 0 (letting the OS pick a free port) and using `mist.after_start` to learn
+/// the actual bound port, to avoid collisions when running many instances or tests
+/// in parallel on the same machine.
+const port = 34817
+
+pub fn main() {
+  let assert Ok(_) =
+    handle_request
+    |> mist.new
+    |> mist.port(port)
+    |> mist.start
+
+  process.sleep_forever()
+}
+
+pub fn handle_request(_req: Request(Connection)) -> Response(ResponseData) {
+  response.new(200)
+  |> response.set_body(mist.Bytes(bytes_tree.from_string(greeting())))
+}
+
+pub fn greeting() -> String {
+  "Hello from web_service!"
+}

--- a/examples/web_service/test/web_service_test.gleam
+++ b/examples/web_service/test/web_service_test.gleam
@@ -1,0 +1,15 @@
+import gleeunit
+import gleeunit/should
+import web_service
+
+pub fn main() {
+  gleeunit.main()
+}
+
+/// A unit test: pure-function-level, no network, no process spawning. See
+/// e2e_test.sh for an integration/end-to-end test that actually starts the
+/// server and makes a real HTTP request against it.
+pub fn greeting_test() {
+  web_service.greeting()
+  |> should.equal("Hello from web_service!")
+}

--- a/gleam/extensions.bzl
+++ b/gleam/extensions.bzl
@@ -183,7 +183,7 @@ gleam_library(
     name = "{name}",
     data = ["gleam.toml"],
     package_name = "{name}",
-    srcs = glob(["src/**/*.gleam", "src/**/*.erl", "src/**/*.mjs"]),
+    srcs = glob(["src/**/*.gleam", "src/**/*.erl", "src/**/*.mjs"], allow_empty = True),
     deps = [{deps}],
     visibility = ["//visibility:public"],
 )

--- a/gleam/extensions.bzl
+++ b/gleam/extensions.bzl
@@ -172,6 +172,17 @@ def _gleam_hex_packages_impl(repository_ctx):
         # Clean up the temp extraction.
         repository_ctx.delete("_tmp_" + name)
 
+        # Some Hex packages consumed transitively (e.g. plain Erlang/rebar3 packages like
+        # hpack_erl, pulled in by Gleam packages that wrap them) ship no gleam.toml at all.
+        # `gleam compile-package` requires one present in the package directory regardless
+        # of the package's own build tooling, so synthesize a minimal one if the extracted
+        # package didn't ship its own.
+        if not repository_ctx.path("{}/gleam.toml".format(name)).exists:
+            repository_ctx.file(
+                "{}/gleam.toml".format(name),
+                'name = "{}"\nversion = "{}"\n'.format(name, version),
+            )
+
         # Generate BUILD.bazel for this package.
         deps_str = ", ".join(['"//{}"'.format(d) for d in deps])
 


### PR DESCRIPTION
Throwaway PR to verify the new examples/web_service (mist + gleam_release + sh_test e2e) actually builds and passes: a substantial new dependency graph (12 hex packages) and a genuinely new runfiles composition (gleam_release invoked as a data dependency of a wrapping sh_test) that I have no way to test locally. Will close without merging once verified or fixed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_