### PR TITLE
fix(gleam): make generated hex_package BUILD template robust to non-Gleam-native deps

### DIFF
--- a/gleam/extensions.bzl
+++ b/gleam/extensions.bzl
@@ -172,6 +172,17 @@ def _gleam_hex_packages_impl(repository_ctx):
         # Clean up the temp extraction.
         repository_ctx.delete("_tmp_" + name)
 
+        # Some Hex packages consumed transitively (e.g. plain Erlang/rebar3 packages like
+        # hpack_erl, pulled in by Gleam packages that wrap them) ship no gleam.toml at all.
+        # `gleam compile-package` requires one present in the package directory regardless
+        # of the package's own build tooling, so synthesize a minimal one if the extracted
+        # package didn't ship its own.
+        if not repository_ctx.path("{}/gleam.toml".format(name)).exists:
+            repository_ctx.file(
+                "{}/gleam.toml".format(name),
+                'name = "{}"\nversion = "{}"\n'.format(name, version),
+            )
+
         # Generate BUILD.bazel for this package.
         deps_str = ", ".join(['"//{}"'.format(d) for d in deps])
 
@@ -183,7 +194,7 @@ gleam_library(
     name = "{name}",
     data = ["gleam.toml"],
     package_name = "{name}",
-    srcs = glob(["src/**/*.gleam", "src/**/*.erl", "src/**/*.mjs"]),
+    srcs = glob(["src/**/*.gleam", "src/**/*.erl", "src/**/*.mjs"], allow_empty = True),
     deps = [{deps}],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Summary

Fourth PR in the stack (after #70, #72, #74, all merged). A small, focused bug fix surfaced while building the next PR in this stack (a web_service example pulling in `mist` and its transitive Hex dependency graph — see the follow-up PR).

The generated `gleam_library` BUILD template for downloaded Hex packages (in `gleam/extensions.bzl`) made two assumptions that happen to hold for the only two Hex packages this repo has ever used (`gleam_stdlib`, `gleeunit`), but don't hold in general:

1. **Every package ships `.mjs` sources.** `srcs = glob(["src/**/*.gleam", "src/**/*.erl", "src/**/*.mjs"])` fails outright for any Erlang-only package (most real Hex packages that don't also support the JavaScript target), since Bazel's default `allow_empty=False` requires *each* pattern in a multi-pattern glob to match something.
2. **Every package ships its own `gleam.toml`.** Some Hex packages consumed transitively by a Gleam package are plain Erlang/rebar3 libraries with no `gleam.toml` at all (e.g. `hpack_erl`, pulled in via `mist -> gramps -> hpack_erl`) — confirmed via its Hex metadata (`build_tools: [rebar3]`) and GitHub repo (`rebar.config`, no `gleam.toml`). `gleam compile-package` requires a `gleam.toml` present in the package directory regardless of the package's own build tooling.

## Fix

- `allow_empty = True` on the `srcs` glob.
- Synthesize a minimal `gleam.toml` (just `name` + `version`, which we already know from the `hex_package` declaration) when the extracted package doesn't ship its own, rather than trying to make `data` conditional per-package.

## Test plan

- [x] Empirically verified as part of the throwaway PR #75 (closed, not merged) used to validate the follow-up web_service example — both failure modes were hit and fixed exactly as described above, and the full `mist` dependency graph (10 packages, several Erlang-only or plain-Erlang) now compiles and runs correctly end-to-end.
- [ ] CI on this PR: existing examples (`gleam_stdlib`, `gleeunit`) are unaffected by either change (single-item lists and packages that do ship a `gleam.toml` take the same code path as before), so this should be a no-op for them and pass as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_