### PR TITLE
feat(examples): add web_service example (mist) demonstrating gleam_release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,15 @@ jobs:
           else
             bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
           fi
+      - name: Run Bazel Tests - examples/web_service Directory
+        working-directory: examples/web_service
+        run: |
+          echo "Running tests in examples/web_service directory with bzlmod=${{ matrix.bzlmod-enabled }}"
+          if ${{ matrix.bzlmod-enabled }}; then
+            bazel test --enable_bzlmod --noenable_workspace --test_output=errors //...
+          else
+            bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
+          fi
       - name: Run Bazel Build - examples/hello_world Directory
         working-directory: examples/hello_world
         run: |

--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ git_override(
 
 ## Usage
 
-See a basic example [here](examples/smoke)
+See a basic example [here](examples/smoke). For a runnable HTTP service with a real
+end-to-end test, see [examples/web_service](examples/web_service).

--- a/examples/web_service/BUILD.bazel
+++ b/examples/web_service/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@rules_gleam//gleam:defs.bzl", "gleam_package", "gleam_release")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+_DEPS = [
+    "@gleam_packages//:exception",
+    "@gleam_packages//:gleam_erlang",
+    "@gleam_packages//:gleam_http",
+    "@gleam_packages//:gleam_otp",
+    "@gleam_packages//:gleam_stdlib",
+    "@gleam_packages//:glisten",
+    "@gleam_packages//:gramps",
+    "@gleam_packages//:hpack_erl",
+    "@gleam_packages//:logging",
+    "@gleam_packages//:mist",
+]
+
+# gleam_package expands to a gleam_library "web_service" (entry_module is not set here --
+# the runnable target below is a gleam_release, not a gleam_binary escript, so the library
+# takes the bare target name, matching gleam.toml's package name) and a gleam_test
+# "web_service_test" for the pure-function unit test.
+gleam_package(
+    name = "web_service",
+    srcs = glob(["src/**/*.gleam"]),
+    gleam_toml = "gleam.toml",
+    test_deps = ["@gleam_packages//:gleeunit"],
+    test_srcs = glob(["test/**/*.gleam"]),
+    deps = _DEPS,
+)
+
+# Packaged as a runfiles-tree binary (not a single-file escript): a real web service
+# doesn't need portability to a machine without Bazel/runfiles the way a CLI tool might,
+# and this shape is what composes with `data` and with container-image rules.
+gleam_release(
+    name = "web_service_bin",
+    dep = ":web_service",
+    entry_module = "web_service",
+)
+
+# An end-to-end/acceptance test: starts the real web_service_bin binary and makes a real
+# HTTP request against it. See test/web_service_test.gleam for the unit-test level.
+sh_test(
+    name = "web_service_e2e_test",
+    srcs = ["e2e_test.sh"],
+    data = [":web_service_bin"],
+    tags = ["requires-network"],
+)

--- a/examples/web_service/MODULE.bazel
+++ b/examples/web_service/MODULE.bazel
@@ -1,0 +1,118 @@
+bazel_dep(name = "muchq_rules_gleam", version = "0.0.1", repo_name = "rules_gleam")
+local_path_override(
+    module_name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+
+gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
+gleam.toolchain(version = "1.14.0")
+
+# mist (a Gleam HTTP server) and its full transitive Hex dependency graph, hand-resolved
+# and hand-checksummed (there's no Hex lockfile-driven dependency resolution yet -- see
+# the project README/CONTRIBUTING for that as a known follow-up). Versions were chosen as
+# the latest stable release of each package as of writing, cross-checked so that every
+# package's declared requirement on every other package in this graph is satisfied.
+gleam.hex_package(
+    name = "gleam_stdlib",
+    sha256 = "1f543afba5d33da493e6087f4e4c4f20d899411343512686c98a8abb2963cf22",
+    version = "1.0.3",
+    deps = [],
+)
+gleam.hex_package(
+    name = "exception",
+    sha256 = "6bdea95248093599391c3b5df1835c5c6a86c353c2f99ce539b450e3432fe117",
+    version = "2.1.1",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "gleam_crypto",
+    sha256 = "2de9e4ef53cf6fee049d4f765731f7178f7a11aefae00eee63bf7536b354ad3f",
+    version = "1.6.0",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "gleam_erlang",
+    sha256 = "1124ad3aa21143e5af0fc5cf3d9529f6db8ca03e43a55711b60b6b7b3874375c",
+    version = "1.3.0",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "gleam_http",
+    sha256 = "82ea6a717c842456188c190afb372665ea56ce13d8559bf3b1dd9e40f619ee0c",
+    version = "4.3.0",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "gleam_otp",
+    sha256 = "ba6a294e295e428ec1562dc1c11ea7530dcb981e8359134beabc8493b7b2258e",
+    version = "1.2.0",
+    deps = [
+        "gleam_erlang",
+        "gleam_stdlib",
+    ],
+)
+gleam.hex_package(
+    name = "logging",
+    sha256 = "bc5f18ce5dd9686100229fe5409bdc3dd5c46d5a7df2f804ad2d8f0dd6c5060e",
+    version = "1.5.0",
+    deps = ["gleam_stdlib"],
+)
+gleam.hex_package(
+    name = "glisten",
+    sha256 = "7795aa50830656f3a0316a6b26595f893c83272da901b3405e31339caa31a10b",
+    version = "9.0.1",
+    deps = [
+        "gleam_erlang",
+        "gleam_otp",
+        "gleam_stdlib",
+        "logging",
+    ],
+)
+gleam.hex_package(
+    name = "gramps",
+    sha256 = "d55636072dee173f6586a5679d3c02ec7a0de3f8646b78c351b72908ff223df7",
+    version = "6.0.1",
+    deps = [
+        "gleam_crypto",
+        "gleam_erlang",
+        "gleam_http",
+        "gleam_stdlib",
+    ],
+)
+gleam.hex_package(
+    name = "hpack_erl",
+    sha256 = "d6137d7079169d8c485c6962dfe261af5b9ef60fbc557344511c1e65e3d95fb0",
+    version = "0.3.0",
+    deps = [],
+)
+gleam.hex_package(
+    name = "mist",
+    sha256 = "1b07f321d5fa0cb162d81496f2de96aeb6ef8980f4f38230a4cc3f849497e020",
+    version = "6.0.3",
+    deps = [
+        "exception",
+        "gleam_erlang",
+        "gleam_http",
+        "gleam_otp",
+        "gleam_stdlib",
+        "glisten",
+        "gramps",
+        "hpack_erl",
+        "logging",
+    ],
+)
+gleam.hex_package(
+    name = "gleeunit",
+    sha256 = "ec31aba74256aea531edf8169931d775bbb384fed0a8a1bdc4dd9354e3e21826",
+    version = "1.11.0",
+    deps = ["gleam_stdlib"],
+)
+use_repo(gleam, "gleam_packages", "gleam_toolchains", "local_config_erlang")
+
+register_toolchains("@gleam_toolchains//:all")
+
+register_toolchains("@local_config_erlang//:erlang_toolchain_definition")

--- a/examples/web_service/WORKSPACE.bazel
+++ b/examples/web_service/WORKSPACE.bazel
@@ -1,0 +1,19 @@
+# Override http_archive for local testing
+local_repository(
+    name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+#---SNIP--- Below here is re-used in the workspace snippet published on releases
+
+######################
+# rules_gleam setup #
+######################
+# Fetches the rules_gleam dependencies.
+# If you want to have a different version of some dependency,
+# you should fetch it *before* calling this.
+# Alternatively, you can skip calling this function, so long as you've
+# already fetched all the dependencies.
+load("@muchq_rules_gleam//gleam:repositories.bzl", "rules_gleam_dependencies")
+
+rules_gleam_dependencies()

--- a/examples/web_service/WORKSPACE.bzlmod
+++ b/examples/web_service/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# When --enable_bzlmod is set, this file replaces WORKSPACE.bazel.
+# Dependencies then come from MODULE.bazel instead.

--- a/examples/web_service/e2e_test.sh
+++ b/examples/web_service/e2e_test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# End-to-end test for the web_service example: starts the real gleam_release binary as a
+# subprocess, makes a real HTTP request against it, and checks the response -- as opposed
+# to web_service_test.gleam, which only unit-tests a pure helper function.
+#
+# Demonstrates the "wrap a gleam_release/gleam_binary executable in a native Bazel test
+# rule" pattern for black-box acceptance testing: no custom Gleam or Erlang test code is
+# needed here, just the compiled binary (as a `data` dependency) plus a normal shell test.
+set -euo pipefail
+
+PORT=34817
+URL="http://localhost:${PORT}/"
+
+# web_service_bin is itself runfiles-aware (see gleam_release's docstring): it looks for
+# RUNFILES_DIR first, before falling back to locating its own ".runfiles" directory. Since
+# this test's own runfiles tree (set up by Bazel's test-setup.sh, rooted at
+# $TEST_SRCDIR/$TEST_WORKSPACE) already contains web_service_bin's compiled dependencies
+# merged in as a `data` dependency, we can just point it there directly.
+export RUNFILES_DIR="$TEST_SRCDIR"
+
+./web_service_bin &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+
+READY=""
+for _ in $(seq 1 40); do
+  if RESPONSE="$(curl -sf --max-time 1 "$URL")"; then
+    READY=1
+    break
+  fi
+  sleep 0.25
+done
+
+if [[ -z "$READY" ]]; then
+  echo "FAIL: server never became ready on $URL" >&2
+  exit 1
+fi
+
+EXPECTED="Hello from web_service!"
+if [[ "$RESPONSE" != "$EXPECTED" ]]; then
+  echo "FAIL: expected response body '$EXPECTED', got '$RESPONSE'" >&2
+  exit 1
+fi
+
+echo "PASS: got expected response body: $RESPONSE"

--- a/examples/web_service/gleam.toml
+++ b/examples/web_service/gleam.toml
@@ -1,0 +1,10 @@
+name = "web_service"
+version = "0.1.0"
+
+[dependencies]
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
+gleam_http = ">= 4.0.0 and < 5.0.0"
+mist = ">= 6.0.0 and < 7.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.11.0 and < 2.0.0"

--- a/examples/web_service/src/web_service.gleam
+++ b/examples/web_service/src/web_service.gleam
@@ -1,0 +1,30 @@
+import gleam/bytes_tree
+import gleam/erlang/process
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
+import mist.{type Connection, type ResponseData}
+
+/// Fixed for simplicity in this example. A real service should prefer binding to
+/// port 0 (letting the OS pick a free port) and using `mist.after_start` to learn
+/// the actual bound port, to avoid collisions when running many instances or tests
+/// in parallel on the same machine.
+const port = 34817
+
+pub fn main() {
+  let assert Ok(_) =
+    handle_request
+    |> mist.new
+    |> mist.port(port)
+    |> mist.start
+
+  process.sleep_forever()
+}
+
+pub fn handle_request(_req: Request(Connection)) -> Response(ResponseData) {
+  response.new(200)
+  |> response.set_body(mist.Bytes(bytes_tree.from_string(greeting())))
+}
+
+pub fn greeting() -> String {
+  "Hello from web_service!"
+}

--- a/examples/web_service/test/web_service_test.gleam
+++ b/examples/web_service/test/web_service_test.gleam
@@ -1,0 +1,15 @@
+import gleeunit
+import gleeunit/should
+import web_service
+
+pub fn main() {
+  gleeunit.main()
+}
+
+/// A unit test: pure-function-level, no network, no process spawning. See
+/// e2e_test.sh for an integration/end-to-end test that actually starts the
+/// server and makes a real HTTP request against it.
+pub fn greeting_test() {
+  web_service.greeting()
+  |> should.equal("Hello from web_service!")
+}


### PR DESCRIPTION
## Summary

Fifth PR in the stack — stacked on #76 (the hex_package template robustness fix this example surfaced the need for). Adds a realistic web-service example exercising `gleam_release` end-to-end, and demonstrates both the unit-test and black-box e2e/acceptance test levels for a service that doesn't fit the escript/CLI mold.

- `mist` (a Gleam HTTP server) and its full transitive Hex dependency graph (10 packages) are hand-declared with verified checksums from the Hex API, since there's no manifest.toml-driven dependency resolution yet (a separate, larger follow-up noted in the original review).
- `web_service`: a `gleam_library`/`gleam_test` pair (via `gleam_package`) with one pure-function unit test.
- `web_service_bin`: a `gleam_release` packaging the same library as a runnable HTTP server, binding a fixed port for simplicity (documented in the source: a real service should prefer port 0 + `mist.after_start` to avoid collisions across parallel test runs).
- `web_service_e2e_test`: a plain `sh_test` (via `rules_shell`, added as a new `bazel_dep`) that starts `web_service_bin` as a real subprocess and makes a real HTTP request against it with `curl` — demonstrating the "wrap a `gleam_release`/`gleam_binary` executable in a native Bazel test rule" e2e pattern with no custom Gleam/Erlang test code required. Sets `RUNFILES_DIR=$TEST_SRCDIR` before invoking the nested binary, composing with `gleam_release`'s own `RUNFILES_DIR`-first lookup.
- Wired into `ci.yaml` alongside the other examples.

## Empirical verification

Verified end-to-end via a throwaway PR (#75, closed, not merged) before opening this one, since this is a large amount of genuinely new, previously-unexercised surface area (a 10-package dependency graph, a new `sh_test`+`gleam_release` runfiles composition):

1. Hit and fixed two real, previously-latent bugs in the hex_package BUILD template generation (now #76, the base of this PR) — the repo's only two prior Hex packages never exercised either code path.
2. Hit and fixed a real bug in my own `gleam_package` macro usage in this example (target named `web_service_lib` defaulted `package_name` to `"web_service_lib"`, but `gleam.toml` declares `name = "web_service"` — correctly caught by the `gleam_package_name_check` validation from an earlier PR in this series).
3. Final green CI run: `//:web_service_test PASSED` and `//:web_service_e2e_test PASSED` — the e2e test genuinely starts the server and gets a real `"Hello from web_service!"` HTTP response back.

Also noted, but explicitly out of scope for this PR: the unrelated `examples/hello_world` build step logs `Error starting application hello_world: ... "no such file or directory" ... "hello_world.app"` — non-fatal, but empirically confirms an open question from the original review (`gleescript_main_shim`'s `application:ensure_all_started` call is indeed a no-op today, since `gleam compile-package` doesn't emit `.app` files). Worth a future cleanup, not touched here.

## Test plan

- [x] Empirically verified via throwaway PR #75 (see above): build, unit test, and e2e test all confirmed genuinely passing.
- [x] `python3 -c "import ast; ast.parse(...)"` / `bash -n` / TOML parse sanity checks on all new files.
- [ ] CI on this PR: should reproduce the same green result seen on the throwaway PR, now against the cleaned-up, properly-based commit history.


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_