### PR TITLE
feat(gleam): add gleam_format_test rule

### DIFF
--- a/examples/smoke/BUILD.bazel
+++ b/examples/smoke/BUILD.bazel
@@ -29,5 +29,8 @@ gleam_release(
 # Fails with a diff if any source or test file isn't already `gleam format`-clean.
 gleam_format_test(
     name = "my_app_format_test",
-    srcs = glob(["src/**/*.gleam", "test/**/*.gleam"]),
+    srcs = glob([
+        "src/**/*.gleam",
+        "test/**/*.gleam",
+    ]),
 )

--- a/examples/smoke/BUILD.bazel
+++ b/examples/smoke/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_gleam//gleam:defs.bzl", "gleam_package", "gleam_release")
+load("@rules_gleam//gleam:defs.bzl", "gleam_format_test", "gleam_package", "gleam_release")
 
 # gleam_package expands to:
 #  - a gleam_library "my_app_lib" (since entry_module is set, the library is not named
@@ -24,4 +24,10 @@ gleam_release(
     name = "my_app_release",
     dep = ":my_app_lib",
     entry_module = "main",
+)
+
+# Fails with a diff if any source or test file isn't already `gleam format`-clean.
+gleam_format_test(
+    name = "my_app_format_test",
+    srcs = glob(["src/**/*.gleam", "test/**/*.gleam"]),
 )

--- a/gleam/BUILD.bazel
+++ b/gleam/BUILD.bazel
@@ -38,6 +38,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//gleam/private:gleam_binary",
+        "//gleam/private:gleam_format_test",
         "//gleam/private:gleam_library",
         "//gleam/private:gleam_release",
         "//gleam/private:gleam_test",

--- a/gleam/defs.bzl
+++ b/gleam/defs.bzl
@@ -1,6 +1,7 @@
 """Public API for the Gleam Bazel rules."""
 
 load("//gleam/private:gleam_binary.bzl", _gleam_binary_rule = "gleam_binary")
+load("//gleam/private:gleam_format_test.bzl", _gleam_format_test_rule = "gleam_format_test")
 load("//gleam/private:gleam_library.bzl", _GleamPackageInfo = "GleamPackageInfo", _gleam_library_rule = "gleam_library")
 load("//gleam/private:gleam_release.bzl", _gleam_release_rule = "gleam_release")
 load("//gleam/private:gleam_test.bzl", _gleam_test_rule = "gleam_test")
@@ -10,6 +11,7 @@ gleam_library = _gleam_library_rule
 gleam_binary = _gleam_binary_rule
 gleam_release = _gleam_release_rule
 gleam_test = _gleam_test_rule
+gleam_format_test = _gleam_format_test_rule
 GleamPackageInfo = _GleamPackageInfo
 
 def gleam_package(

--- a/gleam/private/BUILD.bazel
+++ b/gleam/private/BUILD.bazel
@@ -20,6 +20,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "gleam_format_test",
+    srcs = ["gleam_format_test.bzl"],
+    visibility = ["//gleam:__subpackages__"],
+)
+
+bzl_library(
     name = "gleam_release",
     srcs = ["gleam_release.bzl"],
     visibility = ["//gleam:__subpackages__"],

--- a/gleam/private/gleam_format_test.bzl
+++ b/gleam/private/gleam_format_test.bzl
@@ -1,0 +1,68 @@
+"""Implementation of the gleam_format_test rule.
+
+Runs `gleam format --check` over a set of source files, failing if any of them aren't
+already correctly formatted. Unlike gleam_library/gleam_test, `gleam format` operates
+directly on a list of files or directories -- it doesn't need a gleam.toml, --lib, or any
+other package context -- so this rule is much simpler than the compile-based ones.
+"""
+
+def _gleam_format_test_impl(ctx):
+    gleam_toolchain_info = ctx.toolchains["//gleam:toolchain_type"]
+    gleam_exe_wrapper = gleam_toolchain_info.gleam_executable
+    underlying_gleam_tool = gleam_toolchain_info.underlying_gleam_tool
+
+    test_runner_script = ctx.actions.declare_file(ctx.label.name + "_format_test.sh")
+
+    ws_name = ctx.workspace_name
+
+    def runtime_path(f):
+        return "$TEST_SRCDIR/{ws}/{path}".format(ws = ws_name, path = f.short_path)
+
+    file_args = " ".join(['"{}"'.format(runtime_path(f)) for f in ctx.files.srcs])
+
+    ctx.actions.write(
+        output = test_runner_script,
+        is_executable = True,
+        content = """#!/bin/bash
+# Format check for Gleam sources: {label}
+set -euo pipefail
+
+exec "{wrapper}" "{tool}" format --check {files}
+""".format(
+            label = ctx.label.name,
+            wrapper = runtime_path(gleam_exe_wrapper),
+            tool = runtime_path(underlying_gleam_tool),
+            files = file_args,
+        ),
+    )
+
+    runfiles_files = [gleam_exe_wrapper, underlying_gleam_tool] + list(ctx.files.srcs)
+
+    return [
+        DefaultInfo(
+            executable = test_runner_script,
+            runfiles = ctx.runfiles(files = runfiles_files),
+        ),
+    ]
+
+gleam_format_test = rule(
+    implementation = _gleam_format_test_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            doc = "Gleam source files to check formatting for, e.g. " +
+                  "glob([\"src/**/*.gleam\", \"test/**/*.gleam\"]).",
+            allow_files = [".gleam"],
+            mandatory = True,
+        ),
+    },
+    toolchains = ["//gleam:toolchain_type"],
+    test = True,
+    doc = """\
+Checks that a set of Gleam source files are already formatted per `gleam format`, failing
+the build with a diff if not. Does not modify any files (that would require a separate,
+non-hermetic "fix" target akin to Buildifier's write-back mode; not provided here).
+
+Unlike `gleam_library`/`gleam_test`, this rule doesn't compile anything and doesn't need a
+`gleam.toml`, `deps`, or a `package_name` -- `gleam format` operates directly on files.
+""",
+)


### PR DESCRIPTION
## Summary

Sixth PR in the stack (after #70, #72, #74, #76, #77, all merged). Adds a `gleam format --check`-based test rule, matching the formatting discipline this repo already enforces on its own Starlark via buildifier, but for consumers' Gleam code.

Unlike `gleam_library`/`gleam_test`, `gleam format` operates directly on a list of files/directories with no `gleam.toml` or `--lib` needed (confirmed by reading `gleam`'s own CLI source), so this rule is much simpler than the compile-based ones: it just needs the toolchain's `gleam` executable present in the test's runfiles (referenced via `$TEST_SRCDIR/$TEST_WORKSPACE`, the same pattern `gleam_test` already uses for its `-pa` paths) plus the source files to check. It doesn't modify any files — there's no "fix" mode, matching how Buildifier's own check step in this repo works (`buildifier-lint`/`buildifier` are separate from the auto-fixing pre-commit hook).

Wired into `examples/smoke` as a live usage example (`my_app_format_test`, checking both `src/` and `test/`).

## Empirical verification

Verified with the same canary-based discipline used for earlier rules in this stack, via a throwaway PR (#78, closed, not merged):

1. **Real pass**: `//:my_app_format_test` passed against the already-correctly-formatted `examples/smoke` sources.
2. **Real fail**: pushed a canary commit deliberately misformatting `src/my_app.gleam` (irregular spacing) — `//:my_app_format_test` failed with a genuine diff:
   ```
   error: These files have not been formatted
     - .../src/my_app.gleam
   ```
   while `//:my_app_test` (compilation) was unaffected, confirming the failure is specifically about formatting, not a false positive from a real break.
3. **Real pass again**: reverted the canary, confirmed a clean pass.

## Test plan

- [x] Empirically verified via throwaway PR #78 (see above): real pass, real fail with a genuine diff on bad input, real pass again after revert.
- [x] `python3 -c "import ast; ast.parse(...)"` sanity checks on all modified `.bzl`/`.bazel` files.
- [ ] CI on this PR: should reproduce the same green result seen on the throwaway PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_