### PR TITLE
feat(erlang): add opt-in hermetic Erlang/OTP toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,15 @@ jobs:
           else
             bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
           fi
+      - name: Run Bazel Tests - examples/hermetic_erlang Directory
+        working-directory: examples/hermetic_erlang
+        run: |
+          echo "Running tests in examples/hermetic_erlang directory with bzlmod=${{ matrix.bzlmod-enabled }}"
+          if ${{ matrix.bzlmod-enabled }}; then
+            bazel test --enable_bzlmod --noenable_workspace --test_output=errors //...
+          else
+            bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
+          fi
       - name: Run Bazel Build - examples/hello_world Directory
         working-directory: examples/hello_world
         run: |

--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ Erlang/OTP target.
 
 These rules are early-stage. In particular:
 
-- **Erlang is not hermetic yet.** The Erlang/OTP toolchain is discovered on the host (via
+- **Erlang is not hermetic by default.** The Erlang/OTP toolchain is discovered on the host (via
   `PATH`), not downloaded by Bazel, so builds depend on whatever Erlang/OTP version is installed
-  where Bazel runs. Fetching a hermetic, versioned Erlang/OTP toolchain is tracked as future work.
+  where Bazel runs. An opt-in hermetic toolchain is available via
+  `gleam.erlang_toolchain(otp_version = "27.1.2")` in `MODULE.bazel`, which downloads a prebuilt
+  OTP release instead (see [examples/hermetic_erlang](examples/hermetic_erlang)); it currently
+  supports Linux (glibc-linked, tied to a specific distro/version tag) and macOS, but not Windows.
 - **Test coverage is currently limited to basic end-to-end examples** (see `examples/`) rather
   than a full unit test suite for the rule implementations themselves.
 - `gleam_binary` produces a self-contained `escript`, which still requires an Erlang runtime to

--- a/erlang/private/hermetic_erlang_repository.bzl
+++ b/erlang/private/hermetic_erlang_repository.bzl
@@ -36,7 +36,7 @@ def _sha256_key(os_key, arch):
 
 def _find_executable(repository_ctx, root, name):
     result = repository_ctx.execute(["find", str(root), "-type", "f", "-name", name, "-path", "*/bin/" + name])
-    lines = [l for l in result.stdout.strip().split("\n") if l]
+    lines = [line for line in result.stdout.strip().split("\n") if line]
     if result.return_code != 0 or not lines:
         fail((
             "Could not locate '{name}' inside the extracted Erlang/OTP archive under {root}. " +

--- a/erlang/private/hermetic_erlang_repository.bzl
+++ b/erlang/private/hermetic_erlang_repository.bzl
@@ -1,0 +1,224 @@
+"""Repository rule that downloads a prebuilt Erlang/OTP release instead of relying on PATH.
+
+This is an opt-in alternative to `local_erlang_repository`: instead of discovering whatever
+Erlang/OTP happens to be installed on the host, it fetches a specific prebuilt OTP release
+from the same origins used by the widely-trusted `erlef/setup-beam` GitHub Action:
+
+  - Linux: https://builds.hex.pm/builds/otp/<arch>/<os_version>/OTP-<otp_version>.tar.gz
+    (glibc-linked, tied to a specific distro/version tag such as "ubuntu-22.04" -- there is
+    no portable musl-static build available from this origin).
+  - macOS: https://github.com/erlef/otp_builds/releases/download/OTP-<otp_version>/OTP-<otp_version>-macos-<arch>.tar.gz
+
+Windows is not supported (matching this project's existing lack of Windows support).
+
+Checksums are opt-in per platform via the `sha256` dict. When a platform's checksum is
+missing, the download proceeds unverified and the actual computed checksum is printed so it
+can be pinned in a follow-up change -- mirroring how `bazel_dep`/`http_archive` checksums are
+normally discovered on first use.
+"""
+
+_LINUX_ARCH = {
+    "aarch64": "arm64",
+    "arm64": "arm64",
+    "x86_64": "amd64",
+    "amd64": "amd64",
+}
+
+_MACOS_ARCH = {
+    "aarch64": "aarch64",
+    "arm64": "aarch64",
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+}
+
+def _sha256_key(os_key, arch):
+    return "{}_{}".format(os_key, arch)
+
+def _find_executable(repository_ctx, root, name):
+    result = repository_ctx.execute(["find", str(root), "-type", "f", "-name", name, "-path", "*/bin/" + name])
+    lines = [l for l in result.stdout.strip().split("\n") if l]
+    if result.return_code != 0 or not lines:
+        fail((
+            "Could not locate '{name}' inside the extracted Erlang/OTP archive under {root}. " +
+            "The archive layout may not match what this rule expects -- please file an issue " +
+            "with the otp_version/os you used."
+        ).format(name = name, root = root))
+    return lines[0]
+
+def _hermetic_erlang_repository_impl(repository_ctx):
+    otp_version = repository_ctx.attr.otp_version
+    otp_tag = "OTP-" + otp_version
+    sha256_map = repository_ctx.attr.sha256
+
+    os_name = repository_ctx.os.name.lower()
+    arch = repository_ctx.os.arch
+
+    if "linux" in os_name:
+        os_key = "linux"
+        linux_arch = _LINUX_ARCH.get(arch)
+        if not linux_arch:
+            fail("Unsupported CPU architecture for hermetic Erlang/OTP on Linux: {}".format(arch))
+        os_constraint = "@platforms//os:linux"
+        cpu_constraint = "@platforms//cpu:arm64" if linux_arch == "arm64" else "@platforms//cpu:x86_64"
+
+        url = "https://builds.hex.pm/builds/otp/{arch}/{os_version}/{tag}.tar.gz".format(
+            arch = linux_arch,
+            os_version = repository_ctx.attr.os_version,
+            tag = otp_tag,
+        )
+        checksum_key = _sha256_key(os_key, linux_arch)
+        expected_sha256 = sha256_map.get(checksum_key, "")
+
+        download = repository_ctx.download(
+            url = url,
+            output = "otp.tar.gz",
+            sha256 = expected_sha256,
+        )
+        if not expected_sha256:
+            # buildifier: disable=print
+            print((
+                "NOTE: no sha256 pinned for hermetic Erlang/OTP {tag} on {key}. Downloaded " +
+                "unverified. Pin it by adding sha256 = {{\"{key}\": \"{digest}\"}} to the " +
+                "gleam.erlang_toolchain(...) call."
+            ).format(tag = otp_tag, key = checksum_key, digest = download.sha256))
+
+        repository_ctx.execute(["mkdir", "-p", "otp"])
+        extract_result = repository_ctx.execute([
+            "tar",
+            "-xzf",
+            "otp.tar.gz",
+            "-C",
+            "otp",
+            "--strip-components=1",
+        ])
+        if extract_result.return_code != 0:
+            fail("Failed to extract Erlang/OTP archive: " + extract_result.stderr)
+        repository_ctx.delete("otp.tar.gz")
+
+        otp_root = repository_ctx.path("otp")
+        install_script = str(otp_root) + "/Install"
+        install_result = repository_ctx.execute([install_script, "-minimal", str(otp_root)])
+        if install_result.return_code != 0:
+            fail("Erlang/OTP 'Install -minimal' script failed: " + install_result.stderr)
+
+    elif "mac os" in os_name:
+        os_key = "macos"
+        macos_arch = _MACOS_ARCH.get(arch)
+        if not macos_arch:
+            fail("Unsupported CPU architecture for hermetic Erlang/OTP on macOS: {}".format(arch))
+        os_constraint = "@platforms//os:osx"
+        cpu_constraint = "@platforms//cpu:arm64" if macos_arch == "aarch64" else "@platforms//cpu:x86_64"
+
+        url = "https://github.com/erlef/otp_builds/releases/download/{tag}/{tag}-macos-{arch}.tar.gz".format(
+            tag = otp_tag,
+            arch = macos_arch,
+        )
+        checksum_key = _sha256_key(os_key, macos_arch)
+        expected_sha256 = sha256_map.get(checksum_key, "")
+
+        download = repository_ctx.download(
+            url = url,
+            output = "otp.tar.gz",
+            sha256 = expected_sha256,
+        )
+        if not expected_sha256:
+            # buildifier: disable=print
+            print((
+                "NOTE: no sha256 pinned for hermetic Erlang/OTP {tag} on {key}. Downloaded " +
+                "unverified. Pin it by adding sha256 = {{\"{key}\": \"{digest}\"}} to the " +
+                "gleam.erlang_toolchain(...) call."
+            ).format(tag = otp_tag, key = checksum_key, digest = download.sha256))
+
+        repository_ctx.execute(["mkdir", "-p", "otp"])
+        extract_result = repository_ctx.execute(["tar", "-xzf", "otp.tar.gz", "-C", "otp"])
+        if extract_result.return_code != 0:
+            fail("Failed to extract Erlang/OTP archive: " + extract_result.stderr)
+        repository_ctx.delete("otp.tar.gz")
+
+        otp_root = repository_ctx.path("otp")
+
+    else:
+        fail("Hermetic Erlang/OTP toolchain does not support OS: {}".format(repository_ctx.os.name))
+
+    erl_path = _find_executable(repository_ctx, otp_root, "erl")
+    erlc_path = _find_executable(repository_ctx, otp_root, "erlc")
+    escript_path = _find_executable(repository_ctx, otp_root, "escript")
+    erl_bin_dir = "/".join(erl_path.split("/")[:-1])
+    erlang_root = "/".join(erl_bin_dir.split("/")[:-1])
+
+    erts_include_path = "{}/usr/include".format(erlang_root)
+    if not repository_ctx.path(erts_include_path).exists:
+        erts_include_path = "{}/lib/erlang/usr/include".format(erlang_root)
+
+    erl_libs_path = "{}/lib".format(erlang_root)
+    if not repository_ctx.path(erl_libs_path).exists:
+        erl_libs_path = erlang_root
+
+    version_result = repository_ctx.execute([erl_path, "-eval", 'io:format("~s", [erlang:system_info(otp_release)]), halt().', "-noshell"])
+    erlang_version = version_result.stdout.strip() if version_result.return_code == 0 else otp_version
+
+    build_content = """\
+load("@muchq_rules_gleam//erlang/private:erlang_toolchain_config.bzl", "erlang_toolchain_config")
+load("@muchq_rules_gleam//erlang/private:erlang_toolchain.bzl", "erlang_toolchain")
+
+package(default_visibility = ["//visibility:public"])
+
+erlang_toolchain_config(
+    name = "local_config",
+    escript_path = "{escript_path}",
+    erl_path = "{erl_path}",
+    erlc_path = "{erlc_path}",
+    erts_include_path = "{erts_include_path}",
+    erl_libs_path = "{erl_libs_path}",
+    erlang_version = "{erlang_version}",
+)
+
+erlang_toolchain(
+    name = "local_toolchain",
+    toolchain_config = ":local_config",
+)
+
+toolchain(
+    name = "erlang_toolchain_definition",
+    toolchain_type = "@muchq_rules_gleam//erlang:erlang_toolchain_type",
+    exec_compatible_with = [
+        "{os_constraint}",
+        "{cpu_constraint}",
+    ],
+    target_compatible_with = [
+        "{os_constraint}",
+        "{cpu_constraint}",
+    ],
+    toolchain = ":local_toolchain",
+)
+""".format(
+        escript_path = escript_path,
+        erl_path = erl_path,
+        erlc_path = erlc_path,
+        erts_include_path = erts_include_path,
+        erl_libs_path = erl_libs_path,
+        erlang_version = erlang_version,
+        os_constraint = os_constraint,
+        cpu_constraint = cpu_constraint,
+    )
+
+    repository_ctx.file("BUILD.bazel", build_content)
+
+hermetic_erlang_repository = repository_rule(
+    implementation = _hermetic_erlang_repository_impl,
+    attrs = {
+        "otp_version": attr.string(
+            doc = "Exact Erlang/OTP release to fetch (e.g. \"27.1.2\"), matching an upstream OTP-<version> release tag.",
+            mandatory = True,
+        ),
+        "os_version": attr.string(
+            doc = "Linux distro/version tag used to select the prebuilt OTP archive from builds.hex.pm (e.g. \"ubuntu-22.04\"). Ignored on macOS.",
+            default = "ubuntu-22.04",
+        ),
+        "sha256": attr.string_dict(
+            doc = "Optional map from \"<os>_<arch>\" (e.g. \"linux_amd64\", \"linux_arm64\", \"macos_x86_64\", \"macos_aarch64\") to the expected sha256 of that platform's OTP tarball. Platforms without an entry are downloaded unverified, printing the observed checksum so it can be pinned.",
+            default = {},
+        ),
+    },
+    doc = "Downloads a prebuilt Erlang/OTP release and configures a hermetic toolchain from it.",
+)

--- a/examples/hermetic_erlang/BUILD.bazel
+++ b/examples/hermetic_erlang/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_gleam//gleam:defs.bzl", "gleam_package")
+
+# This target's only purpose is to prove gleam.erlang_toolchain(...) actually works end to
+# end: compiling and running gleeunit tests requires a working `erl`/`erlc`/`escript` from the
+# hermetically-downloaded OTP release, not whatever (if anything) is on the host's PATH.
+gleam_package(
+    name = "hermetic_erlang",
+    srcs = glob(["src/**/*.gleam"]),
+    gleam_toml = "gleam.toml",
+    test_deps = ["@gleam_packages//:gleeunit"],
+    test_srcs = glob(["test/**/*.gleam"]),
+    deps = ["@gleam_packages//:gleam_stdlib"],
+)

--- a/examples/hermetic_erlang/MODULE.bazel
+++ b/examples/hermetic_erlang/MODULE.bazel
@@ -1,0 +1,33 @@
+bazel_dep(name = "muchq_rules_gleam", version = "0.0.1", repo_name = "rules_gleam")
+local_path_override(
+    module_name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
+gleam.toolchain(version = "1.14.0")
+
+# Opt into a hermetic, downloaded Erlang/OTP instead of PATH-based discovery -- this is the
+# entire point of this example. No sha256 is pinned yet: the first CI run prints the observed
+# checksum for each platform it builds on, to be pinned in a follow-up change.
+gleam.erlang_toolchain(otp_version = "27.1.2")
+gleam.hex_package(
+    name = "gleam_stdlib",
+    sha256 = "621d600bb134bc239cb2537630899817b1a42e60a1d46c5e9f3fae39f88c800b",
+    version = "0.60.0",
+    deps = [],
+)
+gleam.hex_package(
+    name = "gleeunit",
+    sha256 = "da9553ce58b67924b3c631f96fe3370c49eb6d6dc6b384ec4862cc4aaa718f3c",
+    version = "1.9.0",
+    deps = ["gleam_stdlib"],
+)
+use_repo(gleam, "gleam_packages", "gleam_toolchains", "local_config_erlang")
+
+register_toolchains("@gleam_toolchains//:all")
+
+register_toolchains("@local_config_erlang//:erlang_toolchain_definition")

--- a/examples/hermetic_erlang/MODULE.bazel
+++ b/examples/hermetic_erlang/MODULE.bazel
@@ -11,9 +11,12 @@ gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
 gleam.toolchain(version = "1.14.0")
 
 # Opt into a hermetic, downloaded Erlang/OTP instead of PATH-based discovery -- this is the
-# entire point of this example. No sha256 is pinned yet: the first CI run prints the observed
-# checksum for each platform it builds on, to be pinned in a follow-up change.
-gleam.erlang_toolchain(otp_version = "27.1.2")
+# entire point of this example. sha256 for linux_amd64 (the only platform CI runs on) was
+# pinned from the checksum printed by the first, unverified CI run.
+gleam.erlang_toolchain(
+    otp_version = "27.1.2",
+    sha256 = {"linux_amd64": "a3eb9b20fb48017c87b4e2867f64b8dfcfaf66cb8f366e3222c9b113c49ee254"},
+)
 gleam.hex_package(
     name = "gleam_stdlib",
     sha256 = "621d600bb134bc239cb2537630899817b1a42e60a1d46c5e9f3fae39f88c800b",

--- a/examples/hermetic_erlang/README.md
+++ b/examples/hermetic_erlang/README.md
@@ -1,0 +1,8 @@
+# hermetic_erlang
+
+This example opts into the hermetic Erlang/OTP toolchain via
+`gleam.erlang_toolchain(otp_version = "...")` in `MODULE.bazel`, instead of the default
+PATH-based discovery of a host-installed Erlang. Bazel downloads a prebuilt OTP release and
+uses it directly, so this example builds and tests correctly even on a machine with no Erlang
+installed at all (CI installs one anyway, for the other examples that still use the default
+local discovery -- this example ignores it entirely).

--- a/examples/hermetic_erlang/WORKSPACE.bazel
+++ b/examples/hermetic_erlang/WORKSPACE.bazel
@@ -1,0 +1,19 @@
+# Override http_archive for local testing
+local_repository(
+    name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+#---SNIP--- Below here is re-used in the workspace snippet published on releases
+
+######################
+# rules_gleam setup #
+######################
+# Fetches the rules_gleam dependencies.
+# If you want to have a different version of some dependency,
+# you should fetch it *before* calling this.
+# Alternatively, you can skip calling this function, so long as you've
+# already fetched all the dependencies.
+load("@muchq_rules_gleam//gleam:repositories.bzl", "rules_gleam_dependencies")
+
+rules_gleam_dependencies()

--- a/examples/hermetic_erlang/WORKSPACE.bzlmod
+++ b/examples/hermetic_erlang/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# When --enable_bzlmod is set, this file replaces WORKSPACE.bazel.
+# Dependencies then come from MODULE.bazel instead.

--- a/examples/hermetic_erlang/gleam.toml
+++ b/examples/hermetic_erlang/gleam.toml
@@ -1,0 +1,8 @@
+name = "hermetic_erlang"
+version = "0.1.0"
+
+[dependencies]
+gleam_stdlib = "~> 0.60 or ~> 0.68 or ~> 0.69"
+
+[dev-dependencies]
+gleeunit = "~> 1.0"

--- a/examples/hermetic_erlang/src/hermetic_erlang.gleam
+++ b/examples/hermetic_erlang/src/hermetic_erlang.gleam
@@ -1,0 +1,3 @@
+pub fn greeting() -> String {
+  "Hello from a hermetically-fetched Erlang/OTP!"
+}

--- a/examples/hermetic_erlang/test/hermetic_erlang_test.gleam
+++ b/examples/hermetic_erlang/test/hermetic_erlang_test.gleam
@@ -1,0 +1,12 @@
+import gleeunit
+import gleeunit/should
+import hermetic_erlang
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn greeting_test() {
+  hermetic_erlang.greeting()
+  |> should.equal("Hello from a hermetically-fetched Erlang/OTP!")
+}

--- a/gleam/extensions.bzl
+++ b/gleam/extensions.bzl
@@ -2,7 +2,10 @@
 
 This extension handles:
 1. Gleam compiler toolchain registration (downloads gleam binary per platform).
-2. Local Erlang detection (finds system-installed Erlang/OTP).
+2. Erlang toolchain configuration: by default, detects system-installed Erlang/OTP on PATH
+   (see erlang/private/local_erlang_repository.bzl); optionally, gleam.erlang_toolchain(...)
+   downloads a specific prebuilt Erlang/OTP release instead, for a hermetic build
+   (see erlang/private/hermetic_erlang_repository.bzl).
 3. Hex package management (downloads and exposes 3p Gleam packages from hex.pm).
 
 Usage in MODULE.bazel:
@@ -13,8 +16,14 @@ gleam.hex_package(name = "gleam_stdlib", version = "0.60.0", sha256 = "...", dep
 gleam.hex_package(name = "gleeunit", version = "1.0.2", sha256 = "...", deps = ["gleam_stdlib"])
 use_repo(gleam, "gleam_toolchains", "local_config_erlang", "gleam_packages")
 ```
+
+To opt into a hermetic, downloaded Erlang/OTP instead of PATH-based discovery:
+```starlark
+gleam.erlang_toolchain(otp_version = "27.1.2")
+```
 """
 
+load("//erlang/private:hermetic_erlang_repository.bzl", "hermetic_erlang_repository")  # buildifier: disable=bzl-visibility
 load("//erlang/private:local_erlang_repository.bzl", "local_erlang_repository")  # buildifier: disable=bzl-visibility
 load(":repositories.bzl", "gleam_register_toolchains")
 
@@ -34,6 +43,26 @@ bytes used to build -- it only turns a silent cross-machine reproducibility gap 
 actionable failure when the host's Erlang/OTP does not match what you expect. Leave unset to
 accept whatever Erlang/OTP release is found.
 """, default = ""),
+})
+
+erlang_toolchain = tag_class(attrs = {
+    "otp_version": attr.string(doc = """\
+Exact Erlang/OTP release to fetch and use hermetically instead of discovering Erlang on PATH
+(e.g. "27.1.2"). When this tag is used, the local PATH-based Erlang discovery in
+erlang/private/local_erlang_repository.bzl is bypassed entirely in favor of downloading a
+prebuilt OTP release from the same origins used by erlef/setup-beam (builds.hex.pm for Linux,
+erlef/otp_builds on GitHub for macOS). Mutually exclusive with gleam.toolchain(erlang_version=...).
+""", mandatory = True),
+    "os_version": attr.string(doc = """\
+Linux distro/version tag used to select the prebuilt OTP archive (e.g. "ubuntu-22.04").
+Ignored on macOS. The Linux archives are glibc-linked and tied to a specific distro version --
+there is no portable musl-static build available from this origin.
+""", default = "ubuntu-22.04"),
+    "sha256": attr.string_dict(doc = """\
+Optional map from "<os>_<arch>" (e.g. "linux_amd64", "linux_arm64", "macos_x86_64",
+"macos_aarch64") to the expected sha256 of that platform's OTP tarball. Platforms without an
+entry are downloaded unverified; the actual checksum is printed so it can be pinned.
+""", default = {}),
 })
 
 hex_package = tag_class(attrs = {
@@ -66,9 +95,17 @@ def _toolchain_extension(module_ctx):
     registrations = {}
     packages = []
     erlang_versions = []
+    hermetic_erlang_toolchains = []
 
     # Collect toolchain registrations and hex packages from all modules.
     for mod in module_ctx.modules:
+        for hermetic in mod.tags.erlang_toolchain:
+            hermetic_erlang_toolchains.append(struct(
+                otp_version = hermetic.otp_version,
+                os_version = hermetic.os_version,
+                sha256 = hermetic.sha256,
+            ))
+
         for toolchain in mod.tags.toolchain:
             if toolchain.name != _DEFAULT_NAME and not mod.is_root:
                 fail("""\
@@ -114,16 +151,40 @@ def _toolchain_extension(module_ctx):
             register = False,
         )
 
-    # Register local Erlang toolchain repository.
-    if len(erlang_versions) > 1:
-        msg = (
-            "Conflicting erlang_version pins were declared across gleam.toolchain calls: {}. " +
-            "Only one Erlang/OTP release can be required at a time since all modules share a " +
-            "single detected Erlang toolchain."
+    # Register the Erlang toolchain repository: hermetic (downloaded) if gleam.erlang_toolchain
+    # was used anywhere, otherwise the default PATH-based local discovery.
+    if len(hermetic_erlang_toolchains) > 1:
+        fail(
+            "Only one gleam.erlang_toolchain(...) call is allowed across all modules, since " +
+            "all modules share a single Erlang toolchain repository. Found: {}".format(
+                [h.otp_version for h in hermetic_erlang_toolchains],
+            ),
         )
-        fail(msg.format(erlang_versions))
-    pinned_erlang_version = erlang_versions[0] if erlang_versions else ""
-    local_erlang_repository(name = "local_config_erlang", erlang_version = pinned_erlang_version)
+
+    if hermetic_erlang_toolchains:
+        if erlang_versions:
+            fail(
+                "gleam.toolchain(erlang_version = ...) and gleam.erlang_toolchain(...) are " +
+                "mutually exclusive: the hermetic toolchain already pins an exact Erlang/OTP " +
+                "release, so a separate PATH-detection version pin is redundant.",
+            )
+        hermetic = hermetic_erlang_toolchains[0]
+        hermetic_erlang_repository(
+            name = "local_config_erlang",
+            otp_version = hermetic.otp_version,
+            os_version = hermetic.os_version,
+            sha256 = hermetic.sha256,
+        )
+    else:
+        if len(erlang_versions) > 1:
+            msg = (
+                "Conflicting erlang_version pins were declared across gleam.toolchain calls: {}. " +
+                "Only one Erlang/OTP release can be required at a time since all modules share a " +
+                "single detected Erlang toolchain."
+            )
+            fail(msg.format(erlang_versions))
+        pinned_erlang_version = erlang_versions[0] if erlang_versions else ""
+        local_erlang_repository(name = "local_config_erlang", erlang_version = pinned_erlang_version)
 
     # Register Hex packages repository if any packages were declared.
     if packages:
@@ -241,6 +302,7 @@ gleam = module_extension(
     implementation = _toolchain_extension,
     tag_classes = {
         "toolchain": gleam_toolchain,
+        "erlang_toolchain": erlang_toolchain,
         "hex_package": hex_package,
     },
 )


### PR DESCRIPTION
## Summary

Third item in the roadmap sequence (after `gleam_release`/web_service and `gleam_format_test`): an **opt-in** hermetic Erlang/OTP toolchain.

- New `gleam.erlang_toolchain(otp_version = "27.1.2")` tag in `MODULE.bazel` downloads a prebuilt OTP release instead of discovering Erlang on the host's `PATH`. Sourced from the same origins used by the widely-trusted `erlef/setup-beam` GitHub Action:
  - Linux: `https://builds.hex.pm/builds/otp/<arch>/<os_version>/OTP-<otp_version>.tar.gz` (glibc-linked, tied to a distro/version tag such as `ubuntu-22.04`; no portable musl-static build available from this origin), followed by that release's own `Install -minimal` script.
  - macOS: `https://github.com/erlef/otp_builds/releases/download/OTP-<otp_version>/OTP-<otp_version>-macos-<arch>.tar.gz`.
  - Windows is not supported (consistent with this project's existing lack of Windows support).
- **Purely additive**: `local_erlang_repository` (PATH-based discovery) remains the default. Nothing changes for existing users who don't call `gleam.erlang_toolchain(...)`. The two are mutually exclusive with the existing `gleam.toolchain(erlang_version = ...)` pin, since the hermetic path already pins an exact release.
- Checksums are opt-in per platform via a `sha256 = {"linux_amd64": "...", ...}` dict. When a platform's entry is missing, the download proceeds unverified and the actual computed checksum is printed so it can be pinned in a follow-up commit — the same two-phase discovery workflow `http_archive` users rely on.
- New `examples/hermetic_erlang` exercises this end-to-end in CI, with a new "Run Bazel Tests - examples/hermetic_erlang Directory" step in `.github/workflows/ci.yaml`.

## Why the exact URLs/checksums are unverified before this PR

`builds.hex.pm` and GitHub release-asset downloads for `erlef/otp_builds` are both unreachable from my sandbox (network allowlist blocks the former; this session's GitHub access is scoped to `muchq/rules_gleam` only, which blocks the latter). The download logic was derived directly from reading `erlef/setup-beam`'s own source. I expect the first CI run may need iteration on the exact URL/tag format or archive layout — I'll watch CI and fix based on the real error output, same as the `examples/web_service` PR.

## Test plan

- [ ] CI: `examples/hermetic_erlang` builds and its `gleeunit` test actually runs (proving the downloaded `erl`/`erlc`/`escript` genuinely work, not just that the archive downloads).
- [ ] Confirm the printed "NOTE: no sha256 pinned..." messages show sensible checksums, to be pinned in a follow-up commit.
- [x] All touched `.bzl` files parse cleanly (Python-AST sanity check); no Bazel available in this sandbox to run a full build.


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_