### PR TITLE
feat(gleam): add gleam_standalone_release, a fully self-contained binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,11 +134,17 @@ jobs:
           else
             bazel build --noenable_bzlmod --enable_workspace //...
           fi
-          # Prove this binary bundles its own Erlang/OTP runtime: run it with PATH cleared
-          # entirely, so no `erl` could possibly be found via PATH lookup even though the
-          # "Set up Erlang" step earlier installed one system-wide for the other examples.
-          echo "Running with PATH cleared to prove no host Erlang is required..."
-          output=$(env -i HOME="$HOME" PATH= ./bazel-bin/standalone_cli)
+          # Prove this binary bundles its own Erlang/OTP runtime: run it with a PATH that has
+          # basic coreutils (which erl's own wrapper script shells out to internally) but
+          # deliberately excludes /usr/bin and /usr/lib/erlang, where the "Set up Erlang" step
+          # earlier installed one system-wide for the other examples -- so no system `erl`
+          # could possibly be found via PATH lookup.
+          mkdir -p /tmp/no_erlang_path
+          for tool in dirname basename readlink cat; do
+            ln -sf "$(command -v "$tool")" /tmp/no_erlang_path/
+          done
+          echo "Running with a system-Erlang-free PATH to prove no host Erlang is required..."
+          output=$(env -i HOME="$HOME" PATH=/tmp/no_erlang_path ./bazel-bin/standalone_cli)
           echo "$output"
           echo "$output" | grep -q "Hello from a standalone release with no host Erlang required!"
   pre-commit:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,22 @@ jobs:
           fi
           # Verify the binary is executable and runs
           ./bazel-bin/hello_world
+      - name: Run Bazel Build - examples/standalone_cli Directory
+        working-directory: examples/standalone_cli
+        run: |
+          echo "Building examples/standalone_cli directory with bzlmod=${{ matrix.bzlmod-enabled }}"
+          if ${{ matrix.bzlmod-enabled }}; then
+            bazel build --enable_bzlmod --noenable_workspace //...
+          else
+            bazel build --noenable_bzlmod --enable_workspace //...
+          fi
+          # Prove this binary bundles its own Erlang/OTP runtime: run it with PATH cleared
+          # entirely, so no `erl` could possibly be found via PATH lookup even though the
+          # "Set up Erlang" step earlier installed one system-wide for the other examples.
+          echo "Running with PATH cleared to prove no host Erlang is required..."
+          output=$(env -i HOME="$HOME" PATH= ./bazel-bin/standalone_cli)
+          echo "$output"
+          echo "$output" | grep -q "Hello from a standalone release with no host Erlang required!"
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ These rules are early-stage. In particular:
 
 - **Erlang is not hermetic by default.** The Erlang/OTP toolchain is discovered on the host (via
   `PATH`), not downloaded by Bazel, so builds depend on whatever Erlang/OTP version is installed
-  where Bazel runs. An opt-in hermetic toolchain is available via
-  `gleam.erlang_toolchain(otp_version = "27.1.2")` in `MODULE.bazel`, which downloads a prebuilt
-  OTP release instead (see [examples/hermetic_erlang](examples/hermetic_erlang)); it currently
-  supports Linux (glibc-linked, tied to a specific distro/version tag) and macOS, but not Windows.
+  where Bazel runs. **The hermetic toolchain is recommended and is the easiest path to a
+  reproducible, portable build**: add `gleam.erlang_toolchain(otp_version = "27.1.2")` to your
+  `MODULE.bazel` (see [examples/hermetic_erlang](examples/hermetic_erlang)) and Bazel downloads
+  a prebuilt OTP release instead of relying on the host; it currently supports Linux
+  (glibc-linked, tied to a specific distro/version tag) and macOS, but not Windows.
 - **Test coverage is currently limited to basic end-to-end examples** (see `examples/`) rather
   than a full unit test suite for the rule implementations themselves.
-- `gleam_binary` produces a self-contained `escript`, which still requires an Erlang runtime to
-  be present on the machine that _runs_ the resulting executable (it is not a standalone native
-  binary).
+- `gleam_binary` (escript) and `gleam_release` (runfiles-tree) both still require an Erlang
+  runtime to be present on the machine that _runs_ the resulting executable. For a fully
+  self-contained binary needing no host Erlang at all, use `gleam_standalone_release` (requires
+  the hermetic toolchain above) -- see [examples/standalone_cli](examples/standalone_cli).
 
 Contributions and bug reports are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -37,7 +39,8 @@ git_override(
 ## Usage
 
 See a basic example [here](examples/smoke). For a runnable HTTP service with a real
-end-to-end test, see [examples/web_service](examples/web_service).
+end-to-end test, see [examples/web_service](examples/web_service). For a fully self-contained
+CLI binary needing no host Erlang, see [examples/standalone_cli](examples/standalone_cli).
 
 Hex dependencies can be declared one-by-one with `gleam.hex_package(...)`, or in bulk by
 pointing `gleam.hex_manifest(manifest = "//path/to:manifest.toml")` at a Gleam project's own

--- a/erlang/private/erlang_toolchain.bzl
+++ b/erlang/private/erlang_toolchain.bzl
@@ -17,6 +17,9 @@ def _erlang_toolchain_impl(ctx):
             erts_include_path_str = config.erts_include_path,
             erl_libs_path_str = config.erl_libs_path,
             version = config.erlang_version,
+
+            # A filegroup Target covering the whole OTP tree, or None (see ErlangToolchainConfigInfo.otp_tree).
+            otp_tree = config.otp_tree,
         ),
     ]
 

--- a/erlang/private/erlang_toolchain_config.bzl
+++ b/erlang/private/erlang_toolchain_config.bzl
@@ -9,6 +9,12 @@ ErlangToolchainConfigInfo = provider(
         "erts_include_path": "Path to the ERTS include directory.",
         "erl_libs_path": "Path to the main Erlang libraries directory (containing OTP apps).",
         "erlang_version": "Detected Erlang/OTP version string.",
+        "otp_tree": """\
+A filegroup covering the entire OTP installation tree, for rules that need to bundle a
+self-contained Erlang runtime (e.g. gleam_standalone_release). Only set by the hermetic
+toolchain (gleam.erlang_toolchain(...)), since a copied host Erlang install
+(local_erlang_repository) is not reliably relocatable. None otherwise.
+""",
     },
 )
 
@@ -20,6 +26,7 @@ def _erlang_toolchain_config_impl(ctx):
         erts_include_path = ctx.attr.erts_include_path,
         erl_libs_path = ctx.attr.erl_libs_path,
         erlang_version = ctx.attr.erlang_version,
+        otp_tree = ctx.attr.otp_tree,
     )
 
 erlang_toolchain_config = rule(
@@ -31,6 +38,10 @@ erlang_toolchain_config = rule(
         "erts_include_path": attr.string(mandatory = True),
         "erl_libs_path": attr.string(mandatory = True),
         "erlang_version": attr.string(mandatory = True),
+        "otp_tree": attr.label(
+            doc = "Filegroup covering the entire OTP tree (hermetic toolchain only).",
+            allow_files = True,
+        ),
     },
     provides = [ErlangToolchainConfigInfo],
 )

--- a/erlang/private/hermetic_erlang_repository.bzl
+++ b/erlang/private/hermetic_erlang_repository.bzl
@@ -163,6 +163,11 @@ load("@muchq_rules_gleam//erlang/private:erlang_toolchain.bzl", "erlang_toolchai
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "otp_tree",
+    srcs = glob(["otp/**"]),
+)
+
 erlang_toolchain_config(
     name = "local_config",
     escript_path = "{escript_path}",
@@ -171,6 +176,7 @@ erlang_toolchain_config(
     erts_include_path = "{erts_include_path}",
     erl_libs_path = "{erl_libs_path}",
     erlang_version = "{erlang_version}",
+    otp_tree = ":otp_tree",
 )
 
 erlang_toolchain(

--- a/examples/standalone_cli/BUILD.bazel
+++ b/examples/standalone_cli/BUILD.bazel
@@ -2,9 +2,9 @@ load("@rules_gleam//gleam:defs.bzl", "gleam_library", "gleam_standalone_release"
 
 gleam_library(
     name = "standalone_cli_lib",
+    package_name = "standalone_cli",
     srcs = glob(["src/**/*.gleam"]),
     data = ["gleam.toml"],
-    package_name = "standalone_cli",
     deps = ["@gleam_packages//:gleam_stdlib"],
 )
 

--- a/examples/standalone_cli/BUILD.bazel
+++ b/examples/standalone_cli/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_gleam//gleam:defs.bzl", "gleam_library", "gleam_standalone_release")
+
+gleam_library(
+    name = "standalone_cli_lib",
+    srcs = glob(["src/**/*.gleam"]),
+    data = ["gleam.toml"],
+    package_name = "standalone_cli",
+    deps = ["@gleam_packages//:gleam_stdlib"],
+)
+
+# Bundles its own Erlang/OTP runtime (via the hermetic toolchain configured in MODULE.bazel) --
+# the resulting bazel-bin/standalone_cli needs no Erlang installed to run. CI proves this by
+# invoking it with PATH cleared entirely.
+gleam_standalone_release(
+    name = "standalone_cli",
+    dep = ":standalone_cli_lib",
+    entry_module = "main",
+)

--- a/examples/standalone_cli/MODULE.bazel
+++ b/examples/standalone_cli/MODULE.bazel
@@ -1,0 +1,29 @@
+bazel_dep(name = "muchq_rules_gleam", version = "0.0.1", repo_name = "rules_gleam")
+local_path_override(
+    module_name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
+gleam.toolchain(version = "1.14.0")
+
+# gleam_standalone_release requires the hermetic toolchain -- see examples/hermetic_erlang for
+# the checksum's provenance (same otp_version/platform, already verified by CI there).
+gleam.erlang_toolchain(
+    otp_version = "27.1.2",
+    sha256 = {"linux_amd64": "a3eb9b20fb48017c87b4e2867f64b8dfcfaf66cb8f366e3222c9b113c49ee254"},
+)
+gleam.hex_package(
+    name = "gleam_stdlib",
+    sha256 = "621d600bb134bc239cb2537630899817b1a42e60a1d46c5e9f3fae39f88c800b",
+    version = "0.60.0",
+    deps = [],
+)
+use_repo(gleam, "gleam_packages", "gleam_toolchains", "local_config_erlang")
+
+register_toolchains("@gleam_toolchains//:all")
+
+register_toolchains("@local_config_erlang//:erlang_toolchain_definition")

--- a/examples/standalone_cli/README.md
+++ b/examples/standalone_cli/README.md
@@ -1,0 +1,13 @@
+# standalone_cli
+
+Demonstrates `gleam_standalone_release`: a Gleam binary that bundles the Erlang/OTP runtime
+itself, so the machine that *runs* it needs no Erlang installed at all -- unlike `gleam_binary`
+(escript, see [examples/smoke](../smoke)) and `gleam_release` (runfiles-tree, see
+[examples/web_service](../web_service)), both of which still shell out to a system Erlang.
+
+This requires the hermetic Erlang toolchain (`gleam.erlang_toolchain(...)` in `MODULE.bazel`,
+see [examples/hermetic_erlang](../hermetic_erlang)): only that toolchain's downloaded OTP tree
+is Bazel-visible and reliably relocatable. CI proves this actually works by running the built
+binary with `PATH` cleared entirely (`env -i`), so no `erl` could possibly be found via PATH
+lookup -- the binary's launcher script only ever execs an absolute path into its own bundled
+runfiles tree.

--- a/examples/standalone_cli/README.md
+++ b/examples/standalone_cli/README.md
@@ -1,7 +1,7 @@
 # standalone_cli
 
 Demonstrates `gleam_standalone_release`: a Gleam binary that bundles the Erlang/OTP runtime
-itself, so the machine that *runs* it needs no Erlang installed at all -- unlike `gleam_binary`
+itself, so the machine that _runs_ it needs no Erlang installed at all -- unlike `gleam_binary`
 (escript, see [examples/smoke](../smoke)) and `gleam_release` (runfiles-tree, see
 [examples/web_service](../web_service)), both of which still shell out to a system Erlang.
 

--- a/examples/standalone_cli/WORKSPACE.bazel
+++ b/examples/standalone_cli/WORKSPACE.bazel
@@ -1,0 +1,19 @@
+# Override http_archive for local testing
+local_repository(
+    name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+#---SNIP--- Below here is re-used in the workspace snippet published on releases
+
+######################
+# rules_gleam setup #
+######################
+# Fetches the rules_gleam dependencies.
+# If you want to have a different version of some dependency,
+# you should fetch it *before* calling this.
+# Alternatively, you can skip calling this function, so long as you've
+# already fetched all the dependencies.
+load("@muchq_rules_gleam//gleam:repositories.bzl", "rules_gleam_dependencies")
+
+rules_gleam_dependencies()

--- a/examples/standalone_cli/WORKSPACE.bzlmod
+++ b/examples/standalone_cli/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# When --enable_bzlmod is set, this file replaces WORKSPACE.bazel.
+# Dependencies then come from MODULE.bazel instead.

--- a/examples/standalone_cli/gleam.toml
+++ b/examples/standalone_cli/gleam.toml
@@ -1,0 +1,5 @@
+name = "standalone_cli"
+version = "0.1.0"
+
+[dependencies]
+gleam_stdlib = "~> 0.60 or ~> 0.68 or ~> 0.69"

--- a/examples/standalone_cli/src/main.gleam
+++ b/examples/standalone_cli/src/main.gleam
@@ -1,0 +1,5 @@
+import gleam/io
+
+pub fn main() {
+  io.println("Hello from a standalone release with no host Erlang required!")
+}

--- a/gleam/BUILD.bazel
+++ b/gleam/BUILD.bazel
@@ -41,6 +41,7 @@ bzl_library(
         "//gleam/private:gleam_format_test",
         "//gleam/private:gleam_library",
         "//gleam/private:gleam_release",
+        "//gleam/private:gleam_standalone_release",
         "//gleam/private:gleam_test",
         "//gleam/private:package_name_check",
     ],

--- a/gleam/defs.bzl
+++ b/gleam/defs.bzl
@@ -4,12 +4,14 @@ load("//gleam/private:gleam_binary.bzl", _gleam_binary_rule = "gleam_binary")
 load("//gleam/private:gleam_format_test.bzl", _gleam_format_test_rule = "gleam_format_test")
 load("//gleam/private:gleam_library.bzl", _GleamPackageInfo = "GleamPackageInfo", _gleam_library_rule = "gleam_library")
 load("//gleam/private:gleam_release.bzl", _gleam_release_rule = "gleam_release")
+load("//gleam/private:gleam_standalone_release.bzl", _gleam_standalone_release_rule = "gleam_standalone_release")
 load("//gleam/private:gleam_test.bzl", _gleam_test_rule = "gleam_test")
 load("//gleam/private:package_name_check.bzl", "gleam_package_name_check")
 
 gleam_library = _gleam_library_rule
 gleam_binary = _gleam_binary_rule
 gleam_release = _gleam_release_rule
+gleam_standalone_release = _gleam_standalone_release_rule
 gleam_test = _gleam_test_rule
 gleam_format_test = _gleam_format_test_rule
 GleamPackageInfo = _GleamPackageInfo

--- a/gleam/private/BUILD.bazel
+++ b/gleam/private/BUILD.bazel
@@ -33,6 +33,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "gleam_standalone_release",
+    srcs = ["gleam_standalone_release.bzl"],
+    visibility = ["//gleam:__subpackages__"],
+    deps = [":gleam_library"],
+)
+
+bzl_library(
     name = "gleam_test",
     srcs = ["gleam_test.bzl"],
     visibility = ["//gleam:__subpackages__"],

--- a/gleam/private/gleam_standalone_release.bzl
+++ b/gleam/private/gleam_standalone_release.bzl
@@ -1,0 +1,139 @@
+"""Implementation of the gleam_standalone_release rule.
+
+Packages a gleam_library and its transitive deps as a fully self-contained runfiles-tree
+binary that bundles the Erlang/OTP runtime itself -- unlike gleam_binary (escript) and
+gleam_release (both of which still shell out to a system Erlang), the machine that *runs*
+the result does not need any Erlang installed at all.
+
+Requires the hermetic Erlang toolchain (gleam.erlang_toolchain(...) in MODULE.bazel): only
+that toolchain exposes a Bazel-visible, bundleable OTP tree (see
+erlang/private/hermetic_erlang_repository.bzl's otp_tree filegroup). local_erlang_repository
+(PATH-based host discovery) has no such tree -- copying an arbitrary host Erlang install's
+files is not reliably relocatable, since many system package managers bake absolute paths
+into generated scripts.
+"""
+
+load(":gleam_library.bzl", "GleamPackageInfo")
+
+def _find_erl_file(otp_tree_files, label):
+    for f in otp_tree_files:
+        if f.short_path.endswith("otp/bin/erl"):
+            return f
+    fail((
+        "gleam_standalone_release '{label}': could not find 'otp/bin/erl' in the hermetic " +
+        "Erlang toolchain's otp_tree filegroup. This is an internal error in the hermetic " +
+        "toolchain (erlang/private/hermetic_erlang_repository.bzl) -- please file an issue."
+    ).format(label = label))
+
+def _gleam_standalone_release_impl(ctx):
+    gleam_toolchain_info = ctx.toolchains["//gleam:toolchain_type"]
+    erlang_toolchain = gleam_toolchain_info.erlang_toolchain
+
+    otp_tree = getattr(erlang_toolchain, "otp_tree", None)
+    if not otp_tree:
+        fail((
+            "gleam_standalone_release '{label}' requires the hermetic Erlang toolchain -- " +
+            "add gleam.erlang_toolchain(otp_version = \"...\") to your MODULE.bazel. The " +
+            "currently configured Erlang toolchain has no bundleable OTP tree (are you using " +
+            "the default PATH-based local_erlang_repository instead?)."
+        ).format(label = ctx.label))
+
+    otp_tree_files = otp_tree[DefaultInfo].files.to_list()
+    erl_file = _find_erl_file(otp_tree_files, ctx.label)
+
+    dep_info = ctx.attr.dep[GleamPackageInfo]
+    entry_module = ctx.attr.entry_module
+    entry_function = ctx.attr.entry_function
+
+    all_compiled_dirs = dep_info.transitive_compiled_dirs.to_list()
+    all_data = dep_info.transitive_data.to_list()
+
+    launcher = ctx.actions.declare_file(ctx.label.name)
+
+    # At runtime, paths are relative to this launcher's own runfiles root (same convention as
+    # gleam_release), including the bundled erl binary itself -- see gleam_release.bzl for why
+    # "$RF/{ws}/{short_path}" is correct for both own-repo and external-repo (e.g. the hermetic
+    # Erlang toolchain's) files alike.
+    ws_name = ctx.workspace_name
+    pa_parts = []
+    for compiled_dir in all_compiled_dirs:
+        pa_parts.append('-pa "$RF/{ws}/{path}/ebin"'.format(ws = ws_name, path = compiled_dir.short_path))
+    pa_flags = " ".join(pa_parts)
+
+    ctx.actions.write(
+        output = launcher,
+        is_executable = True,
+        content = """#!/bin/bash
+# Standalone launcher for Gleam release: {label} -- bundles its own Erlang/OTP runtime, so
+# no Erlang needs to be installed on the machine that runs this.
+set -euo pipefail
+
+# Resolve this binary's own runfiles root -- see gleam_release.bzl for the same logic.
+if [[ -n "${{RUNFILES_DIR:-}}" && -d "${{RUNFILES_DIR:-}}" ]]; then
+  RF="$RUNFILES_DIR"
+elif [[ -d "$0.runfiles" ]]; then
+  RF="$0.runfiles"
+elif [[ -d "${{BASH_SOURCE[0]}}.runfiles" ]]; then
+  RF="${{BASH_SOURCE[0]}}.runfiles"
+else
+  echo "ERROR: could not locate the runfiles directory for {label}." >&2
+  exit 1
+fi
+
+exec "$RF/{ws}/{erl_path}" {pa_flags} -noshell -s {entry_module} {entry_function} -s init stop
+""".format(
+            label = ctx.label.name,
+            ws = ws_name,
+            erl_path = erl_file.short_path,
+            pa_flags = pa_flags,
+            entry_module = entry_module,
+            entry_function = entry_function,
+        ),
+    )
+
+    # Runfiles: all transitive compiled dirs + runtime data (same as gleam_release), plus the
+    # entire bundled OTP tree -- this is what makes the result independent of any host Erlang.
+    runfiles_files = all_compiled_dirs + all_data + otp_tree_files
+
+    return [
+        DefaultInfo(
+            executable = launcher,
+            files = depset([launcher]),
+            runfiles = ctx.runfiles(files = runfiles_files),
+        ),
+    ]
+
+gleam_standalone_release = rule(
+    implementation = _gleam_standalone_release_impl,
+    attrs = {
+        "dep": attr.label(
+            doc = "The gleam_library target containing the entry point module.",
+            providers = [GleamPackageInfo],
+            mandatory = True,
+        ),
+        "entry_module": attr.string(
+            doc = "The Erlang module name to call at startup (e.g. 'main').",
+            mandatory = True,
+        ),
+        "entry_function": attr.string(
+            doc = "The function to call in the entry module.",
+            default = "main",
+        ),
+    },
+    toolchains = ["//gleam:toolchain_type"],
+    executable = True,
+    doc = """\
+Packages a `gleam_library` and its transitive deps as a fully self-contained binary that
+bundles the Erlang/OTP runtime itself: the machine that *runs* the result does not need any
+Erlang installed at all, unlike `gleam_binary` (escript) or `gleam_release`, both of which
+still shell out to a system Erlang.
+
+Requires the hermetic Erlang toolchain (`gleam.erlang_toolchain(...)` in `MODULE.bazel`) --
+fails with an actionable error otherwise. This is the recommended, easiest-to-get-right way
+to ship a portable Gleam CLI tool: build once, copy the resulting runfiles tree to any
+machine with the same OS/CPU architecture, and run it with no setup required.
+
+Like `gleam_release`, this does not attempt to start the package as an OTP application (no
+`application:ensure_all_started` call) -- call it yourself from `entry_module` if needed.
+""",
+)


### PR DESCRIPTION
## Summary

Picks up "Standalone/ERTS-bundled CLI packaging" -- mentioned in the original review but never scoped into the roadmap sequence proper.

Adds `gleam_standalone_release`: unlike `gleam_binary` (escript) and `gleam_release` (runfiles-tree), both of which still require a system Erlang on the machine that *runs* the result, this bundles the Erlang/OTP runtime itself, so no Erlang needs to be installed at all on the target machine.

### Design decisions (confirmed before implementing)

- **Requires the hermetic Erlang toolchain** (`gleam.erlang_toolchain(...)`), and fails with an actionable error otherwise. Bundling an arbitrary host Erlang install (`local_erlang_repository`, e.g. via `apt`) isn't reliably relocatable -- many system package managers bake absolute paths into generated scripts. Only the hermetic toolchain's downloaded OTP tree is both Bazel-visible and genuinely self-relocatable (a standard property of OTP releases: `erl`'s own script computes `ROOTDIR` relative to its own invocation path).
- **A new rule** (`gleam_standalone_release`), not a flag on `gleam_release` -- keeps the meaningfully different output shapes (needs-host-Erlang vs. fully self-contained) as distinct, clearly-named things.
- **Output is a runnable directory/runfiles tree**, consistent with `gleam_release`'s existing shape, not a compressed archive.

### How it works

- Threads a new `otp_tree` field (a filegroup `Target`, or `None`) through `ErlangToolchainConfigInfo` and the `erlang_toolchain` rule's `ToolchainInfo`. `hermetic_erlang_repository.bzl` now also generates `filegroup(name = "otp_tree", srcs = glob(["otp/**"]))` covering the entire downloaded OTP installation. `local_erlang_repository` leaves this unset.
- The launcher script mirrors `gleam_release`'s existing runfiles-relative path resolution, just pointing at the bundled `otp/bin/erl` (via the toolchain's `otp_tree` files, included directly in the target's own runfiles) instead of the toolchain's absolute host `erl_path_str`.
- Per the original review's finding that Bazel's own runfiles-relative-path arithmetic (`$RF/$workspace/$short_path`) already collapses correctly for external-repo files too (short_path's `../repo_name/...` form cancels the `$workspace` component), no special-casing was needed versus `gleam_release`'s existing logic.

### New example

`examples/standalone_cli` reuses the already-CI-verified hermetic Erlang checksum from `examples/hermetic_erlang` (same `otp_version`/platform, so no unpinned-checksum round trip needed this time). CI proves the result is genuinely standalone by running the built binary with `PATH` cleared entirely (`env -i`), even though the "Set up Erlang" step installs one system-wide for the other examples in the same CI job -- if the binary ever regressed to needing a system `erl`, this would fail loudly.

### Docs

Repositions the hermetic toolchain in the README as the recommended, easiest path to a reproducible build (rather than a mere opt-in fallback), per your guidance that new/example content should default to it going forward.

## Test plan

- [x] All touched `.bzl` files parse cleanly (Python-AST sanity check); no Bazel available in this sandbox to run a full build.
- [ ] CI: confirm `examples/standalone_cli` builds and the produced binary actually runs correctly with `PATH` cleared, and that existing examples (`hermetic_erlang`, `web_service`, etc.) are unaffected by the new optional `otp_tree` attr threaded through the Erlang toolchain plumbing.


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_