### PR TITLE
feat(gleam): make the hermetic Erlang toolchain the default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,6 +126,15 @@ jobs:
           else
             bazel build --noenable_bzlmod --enable_workspace //...
           fi
+          # The escript's shebang (`#!/usr/bin/env escript`) looks up `escript` on PATH at run
+          # time, separately from whichever Erlang/OTP built it -- since Erlang is hermetic by
+          # default now, that's the downloaded OTP, not the system one the "Set up Erlang" step
+          # installs (only needed by examples/nested_smoke's explicit PATH-based opt-out).
+          # Prepend the hermetic toolchain's own bin/ so the versions actually match.
+          hermetic_bin="$(bazel info output_base)/external/muchq_rules_gleam++gleam+local_config_erlang/otp/bin"
+          if [[ -d "$hermetic_bin" ]]; then
+            export PATH="$hermetic_bin:$PATH"
+          fi
           # Verify the binary is executable and runs
           ./bazel-bin/hello_world
       - name: Run Bazel Build - examples/standalone_cli Directory

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up Erlang
         run: |
+          # Erlang is hermetic by default now, so most examples download their own OTP release
+          # and never touch this. Only examples/nested_smoke opts out via
+          # gleam.local_erlang_toolchain(), so it still needs a system Erlang on PATH.
           echo "Installing Erlang..."
           # Update package lists to avoid 404 errors for outdated packages
           sudo apt-get update -y
@@ -137,7 +140,7 @@ jobs:
           # Prove this binary bundles its own Erlang/OTP runtime: run it with a PATH that has
           # basic coreutils (which erl's own wrapper script shells out to internally) but
           # deliberately excludes /usr/bin and /usr/lib/erlang, where the "Set up Erlang" step
-          # earlier installed one system-wide for the other examples -- so no system `erl`
+          # earlier installed one system-wide (for examples/nested_smoke) -- so no system `erl`
           # could possibly be found via PATH lookup.
           mkdir -p /tmp/no_erlang_path
           for tool in dirname basename readlink cat; do

--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ Erlang/OTP target.
 
 These rules are early-stage. In particular:
 
-- **Erlang is not hermetic by default.** The Erlang/OTP toolchain is discovered on the host (via
-  `PATH`), not downloaded by Bazel, so builds depend on whatever Erlang/OTP version is installed
-  where Bazel runs. **The hermetic toolchain is recommended and is the easiest path to a
-  reproducible, portable build**: add `gleam.erlang_toolchain(otp_version = "27.1.2")` to your
-  `MODULE.bazel` (see [examples/hermetic_erlang](examples/hermetic_erlang)) and Bazel downloads
-  a prebuilt OTP release instead of relying on the host; it currently supports Linux
-  (glibc-linked, tied to a specific distro/version tag) and macOS, but not Windows.
+- **Erlang is hermetic by default.** Bazel downloads a prebuilt OTP release and uses it
+  directly, rather than discovering Erlang/OTP on the host's `PATH`; it currently supports
+  Linux (glibc-linked, tied to a specific distro/version tag) and macOS, but not Windows. Pin a
+  specific `otp_version`/checksum with `gleam.erlang_toolchain(otp_version = "27.1.2")` in your
+  `MODULE.bazel` (see [examples/hermetic_erlang](examples/hermetic_erlang)), or opt back out to
+  PATH-based host discovery entirely with `gleam.local_erlang_toolchain()` (see
+  [examples/nested_smoke](examples/nested_smoke)) if hermetic downloads aren't practical in
+  your build environment.
 - **Test coverage is currently limited to basic end-to-end examples** (see `examples/`) rather
   than a full unit test suite for the rule implementations themselves.
 - `gleam_binary` (escript) and `gleam_release` (runfiles-tree) both still require an Erlang
   runtime to be present on the machine that _runs_ the resulting executable. For a fully
   self-contained binary needing no host Erlang at all, use `gleam_standalone_release` (requires
-  the hermetic toolchain above) -- see [examples/standalone_cli](examples/standalone_cli).
+  the hermetic toolchain, on by default) -- see [examples/standalone_cli](examples/standalone_cli).
 
 Contributions and bug reports are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ These rules are early-stage. In particular:
   runtime to be present on the machine that _runs_ the resulting executable. For a fully
   self-contained binary needing no host Erlang at all, use `gleam_standalone_release` (requires
   the hermetic toolchain, on by default) -- see [examples/standalone_cli](examples/standalone_cli).
+  Since `gleam_binary`'s escript is compiled with whichever Erlang/OTP built it (the hermetic
+  version by default) but its `#!/usr/bin/env escript` shebang finds `escript` via `PATH` at
+  *run* time, running it on a machine whose Erlang/OTP is meaningfully older can fail with a
+  BEAM-compatibility error -- make sure the two are close enough, or use
+  `gleam_standalone_release` instead to sidestep the question entirely.
 
 Contributions and bug reports are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These rules are early-stage. In particular:
   the hermetic toolchain, on by default) -- see [examples/standalone_cli](examples/standalone_cli).
   Since `gleam_binary`'s escript is compiled with whichever Erlang/OTP built it (the hermetic
   version by default) but its `#!/usr/bin/env escript` shebang finds `escript` via `PATH` at
-  *run* time, running it on a machine whose Erlang/OTP is meaningfully older can fail with a
+  _run_ time, running it on a machine whose Erlang/OTP is meaningfully older can fail with a
   BEAM-compatibility error -- make sure the two are close enough, or use
   `gleam_standalone_release` instead to sidestep the question entirely.
 

--- a/examples/hermetic_erlang/MODULE.bazel
+++ b/examples/hermetic_erlang/MODULE.bazel
@@ -10,9 +10,10 @@ bazel_dep(name = "platforms", version = "1.0.0")
 gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
 gleam.toolchain(version = "1.14.0")
 
-# Opt into a hermetic, downloaded Erlang/OTP instead of PATH-based discovery -- this is the
-# entire point of this example. sha256 for linux_amd64 (the only platform CI runs on) was
-# pinned from the checksum printed by the first, unverified CI run.
+# Erlang is hermetic by default; this pins a specific otp_version/checksum instead of
+# accepting the built-in default -- that's the whole point of this example. sha256 for
+# linux_amd64 (the only platform CI runs on) was pinned from the checksum printed by the
+# first, unverified CI run.
 gleam.erlang_toolchain(
     otp_version = "27.1.2",
     sha256 = {"linux_amd64": "a3eb9b20fb48017c87b4e2867f64b8dfcfaf66cb8f366e3222c9b113c49ee254"},

--- a/examples/hermetic_erlang/README.md
+++ b/examples/hermetic_erlang/README.md
@@ -1,8 +1,10 @@
 # hermetic_erlang
 
-This example opts into the hermetic Erlang/OTP toolchain via
-`gleam.erlang_toolchain(otp_version = "...")` in `MODULE.bazel`, instead of the default
-PATH-based discovery of a host-installed Erlang. Bazel downloads a prebuilt OTP release and
-uses it directly, so this example builds and tests correctly even on a machine with no Erlang
-installed at all (CI installs one anyway, for the other examples that still use the default
-local discovery -- this example ignores it entirely).
+The Erlang/OTP toolchain is hermetic by default (Bazel downloads a prebuilt OTP release and
+uses it directly, rather than discovering one on the host's `PATH`) -- this example just
+demonstrates explicitly pinning a specific `otp_version`/checksum via
+`gleam.erlang_toolchain(...)` in `MODULE.bazel`, instead of accepting the built-in default
+version. It builds and tests correctly even on a machine with no Erlang installed at all (CI
+installs one anyway, for `examples/nested_smoke`, the one example that opts back out to
+PATH-based discovery via `gleam.local_erlang_toolchain()` -- this example ignores it
+entirely).

--- a/examples/nested_smoke/MODULE.bazel
+++ b/examples/nested_smoke/MODULE.bazel
@@ -9,6 +9,10 @@ bazel_dep(name = "platforms", version = "1.0.0")
 
 gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
 gleam.toolchain(version = "1.14.0")
+
+# Opts out of the (now default) hermetic Erlang toolchain, to keep exercising the original
+# PATH-based host discovery in CI -- see erlang/private/local_erlang_repository.bzl.
+gleam.local_erlang_toolchain()
 gleam.hex_package(
     name = "gleam_stdlib",
     sha256 = "621d600bb134bc239cb2537630899817b1a42e60a1d46c5e9f3fae39f88c800b",

--- a/examples/standalone_cli/MODULE.bazel
+++ b/examples/standalone_cli/MODULE.bazel
@@ -10,12 +10,9 @@ bazel_dep(name = "platforms", version = "1.0.0")
 gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
 gleam.toolchain(version = "1.14.0")
 
-# gleam_standalone_release requires the hermetic toolchain -- see examples/hermetic_erlang for
-# the checksum's provenance (same otp_version/platform, already verified by CI there).
-gleam.erlang_toolchain(
-    otp_version = "27.1.2",
-    sha256 = {"linux_amd64": "a3eb9b20fb48017c87b4e2867f64b8dfcfaf66cb8f366e3222c9b113c49ee254"},
-)
+# gleam_standalone_release requires the hermetic toolchain, which is on by default -- no
+# gleam.erlang_toolchain(...) call needed here at all. See examples/hermetic_erlang if you
+# need to pin a specific OTP version/checksum instead of the built-in default.
 gleam.hex_package(
     name = "gleam_stdlib",
     sha256 = "621d600bb134bc239cb2537630899817b1a42e60a1d46c5e9f3fae39f88c800b",

--- a/examples/standalone_cli/README.md
+++ b/examples/standalone_cli/README.md
@@ -5,9 +5,13 @@ itself, so the machine that _runs_ it needs no Erlang installed at all -- unlike
 (escript, see [examples/smoke](../smoke)) and `gleam_release` (runfiles-tree, see
 [examples/web_service](../web_service)), both of which still shell out to a system Erlang.
 
-This requires the hermetic Erlang toolchain (`gleam.erlang_toolchain(...)` in `MODULE.bazel`,
-see [examples/hermetic_erlang](../hermetic_erlang)): only that toolchain's downloaded OTP tree
-is Bazel-visible and reliably relocatable. CI proves this actually works by running the built
-binary with `PATH` cleared entirely (`env -i`), so no `erl` could possibly be found via PATH
-lookup -- the binary's launcher script only ever execs an absolute path into its own bundled
-runfiles tree.
+This requires the hermetic Erlang toolchain, which is on by default -- no `MODULE.bazel`
+configuration needed (see [examples/hermetic_erlang](../hermetic_erlang) if you need to pin a
+specific OTP version/checksum instead of the built-in default). Only the hermetic toolchain's
+downloaded OTP tree is Bazel-visible and reliably relocatable; `gleam_standalone_release`
+fails loudly if `gleam.local_erlang_toolchain()` opts back out to PATH-based discovery.
+
+CI proves this actually works by running the built binary with a PATH that has basic
+coreutils but excludes any system Erlang entirely (`env -i` plus a curated `PATH`), so no
+`erl` could possibly be found via lookup -- the binary's launcher script only ever execs an
+absolute path into its own bundled runfiles tree.

--- a/gleam/extensions.bzl
+++ b/gleam/extensions.bzl
@@ -2,10 +2,11 @@
 
 This extension handles:
 1. Gleam compiler toolchain registration (downloads gleam binary per platform).
-2. Erlang toolchain configuration: by default, detects system-installed Erlang/OTP on PATH
-   (see erlang/private/local_erlang_repository.bzl); optionally, gleam.erlang_toolchain(...)
-   downloads a specific prebuilt Erlang/OTP release instead, for a hermetic build
-   (see erlang/private/hermetic_erlang_repository.bzl).
+2. Erlang toolchain configuration: hermetic by default (Bazel downloads a prebuilt OTP release
+   for you, see erlang/private/hermetic_erlang_repository.bzl), pinned to a specific version via
+   gleam.erlang_toolchain(...); or, if you explicitly opt out with
+   gleam.local_erlang_toolchain(), the previous PATH-based host discovery
+   (erlang/private/local_erlang_repository.bzl).
 3. Hex package management (downloads and exposes 3p Gleam packages from hex.pm), either
    declared package-by-package with gleam.hex_package(...), or in bulk by parsing a Gleam
    project's own manifest.toml lockfile with gleam.hex_manifest(...) -- see below.
@@ -19,15 +20,24 @@ gleam.hex_package(name = "gleeunit", version = "1.0.2", sha256 = "...", deps = [
 use_repo(gleam, "gleam_toolchains", "local_config_erlang", "gleam_packages")
 ```
 
+This already gets you a hermetic Erlang/OTP toolchain (see `_DEFAULT_HERMETIC_OTP_VERSION`
+below for the exact pinned version) with no further configuration. To pin a specific OTP
+release instead of the built-in default:
+```starlark
+gleam.erlang_toolchain(otp_version = "27.1.2")
+```
+
+To opt out of the hermetic toolchain entirely and go back to discovering Erlang/OTP on the
+host's `PATH` (e.g. if hermetic downloads aren't practical in your build environment, or you
+need a platform the hermetic toolchain doesn't support):
+```starlark
+gleam.local_erlang_toolchain()
+```
+
 Instead of declaring every package (and its full transitive graph) by hand, parse them from a
 project's manifest.toml lockfile:
 ```starlark
 gleam.hex_manifest(manifest = "//path/to:manifest.toml")
-```
-
-To opt into a hermetic, downloaded Erlang/OTP instead of PATH-based discovery:
-```starlark
-gleam.erlang_toolchain(otp_version = "27.1.2")
 ```
 """
 
@@ -38,6 +48,17 @@ load(":repositories.bzl", "gleam_register_toolchains")
 
 _DEFAULT_NAME = "gleam"
 
+# Used when Erlang is hermetic by default (no gleam.erlang_toolchain(...) call) -- see
+# erlang/private/hermetic_erlang_repository.bzl. Only linux_amd64 has a pinned checksum today
+# (verified via this repo's own CI, see examples/hermetic_erlang); other platforms download
+# unverified and print the observed checksum, same as an explicit gleam.erlang_toolchain(...)
+# call with no matching sha256 entry.
+_DEFAULT_HERMETIC_OTP_VERSION = "27.1.2"
+_DEFAULT_HERMETIC_OS_VERSION = "ubuntu-22.04"
+_DEFAULT_HERMETIC_SHA256 = {
+    "linux_amd64": "a3eb9b20fb48017c87b4e2867f64b8dfcfaf66cb8f366e3222c9b113c49ee254",
+}
+
 gleam_toolchain = tag_class(attrs = {
     "name": attr.string(doc = """\
 Base name for generated repositories, allowing more than one gleam toolchain to be registered.
@@ -46,21 +67,22 @@ Overriding the default is only permitted in the root module.
     "version": attr.string(doc = "Explicit version of gleam.", mandatory = True),
     "erlang_version": attr.string(doc = """\
 Optional exact Erlang/OTP release to require (e.g. "26"), checked against
-erlang:system_info(otp_release) on the host Erlang found on PATH. The Erlang toolchain is not
-yet hermetic (see erlang/private/local_erlang_repository.bzl), so this does not pin the actual
-bytes used to build -- it only turns a silent cross-machine reproducibility gap into a loud,
-actionable failure when the host's Erlang/OTP does not match what you expect. Leave unset to
-accept whatever Erlang/OTP release is found.
+erlang:system_info(otp_release) on the host Erlang found on PATH. Only applies when
+gleam.local_erlang_toolchain() has also been used to opt out of the (now default) hermetic
+toolchain -- PATH-based discovery does not pin the actual bytes used to build, so this only
+turns a silent cross-machine reproducibility gap into a loud, actionable failure when the
+host's Erlang/OTP does not match what you expect. Leave unset to accept whatever Erlang/OTP
+release is found.
 """, default = ""),
 })
 
 erlang_toolchain = tag_class(attrs = {
     "otp_version": attr.string(doc = """\
-Exact Erlang/OTP release to fetch and use hermetically instead of discovering Erlang on PATH
-(e.g. "27.1.2"). When this tag is used, the local PATH-based Erlang discovery in
-erlang/private/local_erlang_repository.bzl is bypassed entirely in favor of downloading a
-prebuilt OTP release from the same origins used by erlef/setup-beam (builds.hex.pm for Linux,
-erlef/otp_builds on GitHub for macOS). Mutually exclusive with gleam.toolchain(erlang_version=...).
+Exact Erlang/OTP release to fetch hermetically (e.g. "27.1.2"), overriding the version Erlang
+is already hermetic with by default even without this tag. Downloads a prebuilt OTP release
+from the same origins used by erlef/setup-beam (builds.hex.pm for Linux, erlef/otp_builds on
+GitHub for macOS). Mutually exclusive with gleam.local_erlang_toolchain() and
+gleam.toolchain(erlang_version=...).
 """, mandatory = True),
     "os_version": attr.string(doc = """\
 Linux distro/version tag used to select the prebuilt OTP archive (e.g. "ubuntu-22.04").
@@ -73,6 +95,13 @@ Optional map from "<os>_<arch>" (e.g. "linux_amd64", "linux_arm64", "macos_x86_6
 entry are downloaded unverified; the actual checksum is printed so it can be pinned.
 """, default = {}),
 })
+
+local_erlang_toolchain = tag_class(attrs = {}, doc = """\
+Opts out of the (now default) hermetic Erlang/OTP toolchain, reverting to discovering
+Erlang/OTP on the host's PATH instead (see erlang/private/local_erlang_repository.bzl). Use
+this if hermetic downloads aren't practical in your build environment, or you need a platform
+the hermetic toolchain doesn't support. Mutually exclusive with gleam.erlang_toolchain(...).
+""")
 
 hex_package = tag_class(attrs = {
     "name": attr.string(doc = "Hex package name (e.g. 'gleam_stdlib').", mandatory = True),
@@ -118,6 +147,7 @@ def _toolchain_extension(module_ctx):
     package_sources = {}  # package name -> "gleam.hex_package(...)" or the manifest label, for conflict errors
     erlang_versions = []
     hermetic_erlang_toolchains = []
+    local_erlang_requested = False
 
     def _add_package(name, version, sha256, deps, source_desc):
         if name in package_sources:
@@ -136,6 +166,9 @@ def _toolchain_extension(module_ctx):
                 os_version = hermetic.os_version,
                 sha256 = hermetic.sha256,
             ))
+
+        if mod.tags.local_erlang_toolchain:
+            local_erlang_requested = True
 
         for toolchain in mod.tags.toolchain:
             if toolchain.name != _DEFAULT_NAME and not mod.is_root:
@@ -209,8 +242,9 @@ def _toolchain_extension(module_ctx):
             register = False,
         )
 
-    # Register the Erlang toolchain repository: hermetic (downloaded) if gleam.erlang_toolchain
-    # was used anywhere, otherwise the default PATH-based local discovery.
+    # Register the Erlang toolchain repository. Hermetic by default (either the built-in
+    # version, or whatever gleam.erlang_toolchain(...) pins); gleam.local_erlang_toolchain()
+    # opts back out to PATH-based host discovery.
     if len(hermetic_erlang_toolchains) > 1:
         fail(
             "Only one gleam.erlang_toolchain(...) call is allowed across all modules, since " +
@@ -219,19 +253,35 @@ def _toolchain_extension(module_ctx):
             ),
         )
 
-    if hermetic_erlang_toolchains:
+    if hermetic_erlang_toolchains and local_erlang_requested:
+        fail(
+            "gleam.erlang_toolchain(...) and gleam.local_erlang_toolchain() are mutually " +
+            "exclusive: the former pins a hermetic OTP release, the latter opts out of the " +
+            "hermetic toolchain entirely.",
+        )
+
+    if hermetic_erlang_toolchains or not local_erlang_requested:
         if erlang_versions:
             fail(
-                "gleam.toolchain(erlang_version = ...) and gleam.erlang_toolchain(...) are " +
-                "mutually exclusive: the hermetic toolchain already pins an exact Erlang/OTP " +
-                "release, so a separate PATH-detection version pin is redundant.",
+                "gleam.toolchain(erlang_version = ...) only applies when opting out of the " +
+                "hermetic toolchain -- add gleam.local_erlang_toolchain() to your MODULE.bazel " +
+                "if you need PATH-based Erlang/OTP version validation, or remove erlang_version " +
+                "since the hermetic toolchain (the default) already pins an exact release.",
             )
-        hermetic = hermetic_erlang_toolchains[0]
+        if hermetic_erlang_toolchains:
+            hermetic = hermetic_erlang_toolchains[0]
+            otp_version = hermetic.otp_version
+            os_version = hermetic.os_version
+            sha256 = hermetic.sha256
+        else:
+            otp_version = _DEFAULT_HERMETIC_OTP_VERSION
+            os_version = _DEFAULT_HERMETIC_OS_VERSION
+            sha256 = _DEFAULT_HERMETIC_SHA256
         hermetic_erlang_repository(
             name = "local_config_erlang",
-            otp_version = hermetic.otp_version,
-            os_version = hermetic.os_version,
-            sha256 = hermetic.sha256,
+            otp_version = otp_version,
+            os_version = os_version,
+            sha256 = sha256,
         )
     else:
         if len(erlang_versions) > 1:
@@ -361,6 +411,7 @@ gleam = module_extension(
     tag_classes = {
         "toolchain": gleam_toolchain,
         "erlang_toolchain": erlang_toolchain,
+        "local_erlang_toolchain": local_erlang_toolchain,
         "hex_package": hex_package,
         "hex_manifest": hex_manifest,
     },

--- a/gleam/private/gleam_standalone_release.bzl
+++ b/gleam/private/gleam_standalone_release.bzl
@@ -5,12 +5,12 @@ binary that bundles the Erlang/OTP runtime itself -- unlike gleam_binary (escrip
 gleam_release (both of which still shell out to a system Erlang), the machine that *runs*
 the result does not need any Erlang installed at all.
 
-Requires the hermetic Erlang toolchain (gleam.erlang_toolchain(...) in MODULE.bazel): only
-that toolchain exposes a Bazel-visible, bundleable OTP tree (see
-erlang/private/hermetic_erlang_repository.bzl's otp_tree filegroup). local_erlang_repository
-(PATH-based host discovery) has no such tree -- copying an arbitrary host Erlang install's
-files is not reliably relocatable, since many system package managers bake absolute paths
-into generated scripts.
+Requires the hermetic Erlang toolchain, which is on by default: only that toolchain exposes a
+Bazel-visible, bundleable OTP tree (see erlang/private/hermetic_erlang_repository.bzl's
+otp_tree filegroup). If gleam.local_erlang_toolchain() opts back out to PATH-based host
+discovery (erlang/private/local_erlang_repository.bzl), there is no such tree -- copying an
+arbitrary host Erlang install's files is not reliably relocatable, since many system package
+managers bake absolute paths into generated scripts.
 """
 
 load(":gleam_library.bzl", "GleamPackageInfo")
@@ -32,10 +32,11 @@ def _gleam_standalone_release_impl(ctx):
     otp_tree = getattr(erlang_toolchain, "otp_tree", None)
     if not otp_tree:
         fail((
-            "gleam_standalone_release '{label}' requires the hermetic Erlang toolchain -- " +
-            "add gleam.erlang_toolchain(otp_version = \"...\") to your MODULE.bazel. The " +
-            "currently configured Erlang toolchain has no bundleable OTP tree (are you using " +
-            "the default PATH-based local_erlang_repository instead?)."
+            "gleam_standalone_release '{label}' requires the hermetic Erlang toolchain, which " +
+            "is on by default -- but this build has no bundleable OTP tree, which means " +
+            "gleam.local_erlang_toolchain() must be set in your MODULE.bazel, opting back out " +
+            "to PATH-based discovery (erlang/private/local_erlang_repository.bzl). Remove that " +
+            "call to use gleam_standalone_release."
         ).format(label = ctx.label))
 
     otp_tree_files = otp_tree[DefaultInfo].files.to_list()
@@ -128,10 +129,11 @@ bundles the Erlang/OTP runtime itself: the machine that *runs* the result does n
 Erlang installed at all, unlike `gleam_binary` (escript) or `gleam_release`, both of which
 still shell out to a system Erlang.
 
-Requires the hermetic Erlang toolchain (`gleam.erlang_toolchain(...)` in `MODULE.bazel`) --
-fails with an actionable error otherwise. This is the recommended, easiest-to-get-right way
-to ship a portable Gleam CLI tool: build once, copy the resulting runfiles tree to any
-machine with the same OS/CPU architecture, and run it with no setup required.
+Requires the hermetic Erlang toolchain, which is on by default -- fails with an actionable
+error if `gleam.local_erlang_toolchain()` has opted back out to PATH-based discovery. This is
+the recommended, easiest-to-get-right way to ship a portable Gleam CLI tool: build once, copy
+the resulting runfiles tree to any machine with the same OS/CPU architecture, and run it with
+no setup required.
 
 Like `gleam_release`, this does not attempt to start the package as an OTP application (no
 `application:ensure_all_started` call) -- call it yourself from `entry_module` if needed.


### PR DESCRIPTION
## Summary

Flips the Erlang toolchain's default from PATH-based host discovery to the hermetic, downloaded OTP release. This is a behavior change for any consumer that doesn't already call `gleam.erlang_toolchain(...)` explicitly -- they'll now get a downloaded, version-pinned OTP release instead of whatever Erlang happens to be on the host's `PATH`.

### What changed

- **New default**: no `gleam.erlang_toolchain(...)` call → hermetic toolchain using a built-in default version/checksum (`27.1.2`, `linux_amd64` checksum verified via this repo's own CI). `gleam.erlang_toolchain(otp_version = "...")` still works exactly as before, now overriding the built-in default rather than opting into hermetic in the first place.
- **New opt-out**: `gleam.local_erlang_toolchain()` explicitly reverts to PATH-based host discovery, for build environments where hermetic downloads aren't practical, or a platform the hermetic toolchain doesn't support yet.
- **`gleam.toolchain(erlang_version = ...)`** (the PATH-based version-validation pin) now only applies when `gleam.local_erlang_toolchain()` is also used, and fails loudly with an actionable message otherwise -- previously it validated against whatever PATH-discovered Erlang was found; by default there's no such thing to validate anymore.
- `gleam.erlang_toolchain(...)` and `gleam.local_erlang_toolchain()` are mutually exclusive (fails loudly if both are set).

### Examples updated

- **`examples/nested_smoke`** now explicitly calls `gleam.local_erlang_toolchain()`, so CI keeps exercising the PATH-based path -- every other example gets hermetic Erlang automatically now, so without this, the opt-out would have zero test coverage.
- **`examples/standalone_cli`** drops its previously-required `gleam.erlang_toolchain(...)` call entirely: `gleam_standalone_release` now works with zero Erlang-related `MODULE.bazel` configuration, since hermetic is already the default.
- **`examples/hermetic_erlang`** is repositioned in its docs/comments: it no longer demonstrates "opting in" (that's automatic now), it demonstrates pinning a specific `otp_version`/checksum instead of accepting the built-in default.

### Docs

README's "Status" section rewritten to describe hermetic-by-default, the opt-out, and where to look for both. `gleam/extensions.bzl`'s module docstring and each tag class's `doc` string updated to match.

## Test plan

- [x] All touched `.bzl` files parse cleanly (Python-AST sanity check); no Bazel available in this sandbox to run a full build.
- [ ] CI: confirm every example still builds/tests correctly under the new default -- `examples/smoke`, `web_service`, `gazelle_smoke`, `hello_world` (previously PATH-based, now hermetic) and `nested_smoke` (explicit opt-out, still PATH-based) all need to pass, plus `hermetic_erlang` and `standalone_cli` (already hermetic, now via a different code path for the latter).


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_