### PR TITLE
fix(gleam): make gleam_release genuinely portable, verify on a fresh Docker container

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,12 +130,15 @@ jobs:
 
           url="http://localhost:34817/"
           ready=""
-          for _ in $(seq 1 40); do
+          # A freshly pulled container plus a cold Erlang/OTP VM boot reading BEAM files off a
+          # bind-mounted volume can take noticeably longer than a warm, same-machine start --
+          # give it up to a minute rather than the few seconds that's plenty outside Docker.
+          for _ in $(seq 1 120); do
             if response="$(curl -sf --max-time 1 "$url")"; then
               ready=1
               break
             fi
-            sleep 0.25
+            sleep 0.5
           done
           if [[ -z "$ready" ]]; then
             echo "FAIL: server never became ready on $url" >&2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,47 @@ jobs:
           else
             bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
           fi
+      - name: Verify examples/web_service's gleam_release on a fresh, Erlang-free machine (Docker)
+        working-directory: examples/web_service
+        run: |
+          # Same rationale as examples/standalone_cli: gleam_release also bundles the
+          # hermetic toolchain's OTP tree now, so it should be just as portable. Prove it on
+          # a genuinely fresh Docker container with no Erlang installed, not just this
+          # machine with PATH tricks.
+          if ${{ matrix.bzlmod-enabled }}; then
+            bazel build --enable_bzlmod --noenable_workspace //:web_service_bin
+          else
+            bazel build --noenable_bzlmod --enable_workspace //:web_service_bin
+          fi
+          rm -rf /tmp/portable_web_service
+          mkdir -p /tmp/portable_web_service
+          cp -L bazel-bin/web_service_bin /tmp/portable_web_service/web_service_bin
+          cp -rL bazel-bin/web_service_bin.runfiles /tmp/portable_web_service/web_service_bin.runfiles
+
+          container_id=$(docker run -d --rm -p 34817:34817 -v /tmp/portable_web_service:/artifact:ro ubuntu:24.04 /artifact/web_service_bin)
+          trap 'docker stop "$container_id" >/dev/null 2>&1 || true' EXIT
+
+          url="http://localhost:34817/"
+          ready=""
+          for _ in $(seq 1 40); do
+            if response="$(curl -sf --max-time 1 "$url")"; then
+              ready=1
+              break
+            fi
+            sleep 0.25
+          done
+          if [[ -z "$ready" ]]; then
+            echo "FAIL: server never became ready on $url" >&2
+            docker logs "$container_id" || true
+            exit 1
+          fi
+
+          expected="Hello from web_service!"
+          if [[ "$response" != "$expected" ]]; then
+            echo "FAIL: expected response body '$expected', got '$response'" >&2
+            exit 1
+          fi
+          echo "PASS: got expected response from a container with no Erlang installed: $response"
       - name: Run Bazel Tests - examples/hermetic_erlang Directory
         working-directory: examples/hermetic_erlang
         run: |
@@ -146,17 +187,19 @@ jobs:
           else
             bazel build --noenable_bzlmod --enable_workspace //...
           fi
-          # Prove this binary bundles its own Erlang/OTP runtime: run it with a PATH that has
-          # basic coreutils (which erl's own wrapper script shells out to internally) but
-          # deliberately excludes /usr/bin and /usr/lib/erlang, where the "Set up Erlang" step
-          # earlier installed one system-wide (for examples/nested_smoke) -- so no system `erl`
-          # could possibly be found via PATH lookup.
-          mkdir -p /tmp/no_erlang_path
-          for tool in dirname basename readlink cat; do
-            ln -sf "$(command -v "$tool")" /tmp/no_erlang_path/
-          done
-          echo "Running with a system-Erlang-free PATH to prove no host Erlang is required..."
-          output=$(env -i HOME="$HOME" PATH=/tmp/no_erlang_path ./bazel-bin/standalone_cli)
+      - name: Verify examples/standalone_cli on a fresh, Erlang-free machine (Docker)
+        working-directory: examples/standalone_cli
+        run: |
+          # A same-machine PATH trick can't fully rule out accidentally finding a system
+          # Erlang; copy the *actual* build output onto a genuinely fresh Docker container
+          # that never had Erlang installed at all, dereferencing every runfiles symlink
+          # (cp -L) into real files first, so the copy has no dependency on this machine's
+          # Bazel cache either.
+          rm -rf /tmp/portable_standalone_cli
+          mkdir -p /tmp/portable_standalone_cli
+          cp -L bazel-bin/standalone_cli /tmp/portable_standalone_cli/standalone_cli
+          cp -rL bazel-bin/standalone_cli.runfiles /tmp/portable_standalone_cli/standalone_cli.runfiles
+          output=$(docker run --rm -v /tmp/portable_standalone_cli:/artifact:ro ubuntu:24.04 /artifact/standalone_cli)
           echo "$output"
           echo "$output" | grep -q "Hello from a standalone release with no host Erlang required!"
   pre-commit:

--- a/README.md
+++ b/README.md
@@ -17,15 +17,18 @@ These rules are early-stage. In particular:
   your build environment.
 - **Test coverage is currently limited to basic end-to-end examples** (see `examples/`) rather
   than a full unit test suite for the rule implementations themselves.
-- `gleam_binary` (escript) and `gleam_release` (runfiles-tree) both still require an Erlang
-  runtime to be present on the machine that _runs_ the resulting executable. For a fully
-  self-contained binary needing no host Erlang at all, use `gleam_standalone_release` (requires
-  the hermetic toolchain, on by default) -- see [examples/standalone_cli](examples/standalone_cli).
-  Since `gleam_binary`'s escript is compiled with whichever Erlang/OTP built it (the hermetic
-  version by default) but its `#!/usr/bin/env escript` shebang finds `escript` via `PATH` at
-  _run_ time, running it on a machine whose Erlang/OTP is meaningfully older can fail with a
-  BEAM-compatibility error -- make sure the two are close enough, or use
-  `gleam_standalone_release` instead to sidestep the question entirely.
+- `gleam_binary` (escript) always requires a compatible Erlang runtime to be present on the
+  machine that _runs_ the resulting executable: its `#!/usr/bin/env escript` shebang finds
+  `escript` via `PATH` at _run_ time, separately from whichever Erlang/OTP built it (the
+  hermetic version by default), so running it on a machine whose Erlang/OTP is meaningfully
+  older can fail with a BEAM-compatibility error. `gleam_release` and `gleam_standalone_release`
+  don't have this problem under the hermetic toolchain (the default): both bundle the
+  toolchain's own OTP tree into their runfiles, so the result is genuinely portable to any
+  machine with the same OS/CPU architecture, no Erlang installed there required.
+  `gleam_standalone_release` requires the hermetic toolchain outright (fails otherwise);
+  `gleam_release` falls back to a PATH lookup (same caveat as `gleam_binary`) if
+  `gleam.local_erlang_toolchain()` opts out of it. See
+  [examples/standalone_cli](examples/standalone_cli).
 
 Contributions and bug reports are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/examples/web_service/src/web_service.gleam
+++ b/examples/web_service/src/web_service.gleam
@@ -15,6 +15,7 @@ pub fn main() {
     handle_request
     |> mist.new
     |> mist.port(port)
+    |> mist.bind("0.0.0.0")
     |> mist.start
 
   process.sleep_forever()

--- a/gleam/private/BUILD.bazel
+++ b/gleam/private/BUILD.bazel
@@ -29,14 +29,26 @@ bzl_library(
     name = "gleam_release",
     srcs = ["gleam_release.bzl"],
     visibility = ["//gleam:__subpackages__"],
-    deps = [":gleam_library"],
+    deps = [
+        ":erlang_otp_tree",
+        ":gleam_library",
+    ],
 )
 
 bzl_library(
     name = "gleam_standalone_release",
     srcs = ["gleam_standalone_release.bzl"],
     visibility = ["//gleam:__subpackages__"],
-    deps = [":gleam_library"],
+    deps = [
+        ":erlang_otp_tree",
+        ":gleam_library",
+    ],
+)
+
+bzl_library(
+    name = "erlang_otp_tree",
+    srcs = ["erlang_otp_tree.bzl"],
+    visibility = ["//gleam:__subpackages__"],
 )
 
 bzl_library(

--- a/gleam/private/erlang_otp_tree.bzl
+++ b/gleam/private/erlang_otp_tree.bzl
@@ -1,0 +1,22 @@
+"""Shared helper for rules that bundle the hermetic Erlang toolchain's OTP tree.
+
+Used by gleam_release (when the hermetic toolchain is active) and gleam_standalone_release
+(which requires it) to locate the bundled `erl` executable within the toolchain's `otp_tree`
+filegroup -- see erlang/private/hermetic_erlang_repository.bzl.
+"""
+
+def find_erl_file(otp_tree_files, label):
+    """Returns the `otp/bin/erl` File within a hermetic toolchain's otp_tree filegroup files.
+
+    Fails with an actionable error if not found -- this would indicate an internal error in
+    the hermetic toolchain itself (a mismatch in the extracted OTP archive's layout), not a
+    user error.
+    """
+    for f in otp_tree_files:
+        if f.short_path.endswith("otp/bin/erl"):
+            return f
+    fail((
+        "'{label}': could not find 'otp/bin/erl' in the hermetic Erlang toolchain's otp_tree " +
+        "filegroup. This is an internal error in the hermetic toolchain " +
+        "(erlang/private/hermetic_erlang_repository.bzl) -- please file an issue."
+    ).format(label = label))

--- a/gleam/private/erlang_otp_tree.bzl
+++ b/gleam/private/erlang_otp_tree.bzl
@@ -11,6 +11,13 @@ def find_erl_file(otp_tree_files, label):
     Fails with an actionable error if not found -- this would indicate an internal error in
     the hermetic toolchain itself (a mismatch in the extracted OTP archive's layout), not a
     user error.
+
+    Args:
+      otp_tree_files: list of File, the hermetic toolchain's otp_tree filegroup files.
+      label: Label of the rule doing the lookup, used only for the error message.
+
+    Returns:
+      The `otp/bin/erl` File.
     """
     for f in otp_tree_files:
         if f.short_path.endswith("otp/bin/erl"):

--- a/gleam/private/gleam_release.bzl
+++ b/gleam/private/gleam_release.bzl
@@ -9,7 +9,8 @@ runtime data available alongside the compiled code (see gleam_binary for the sin
 escript alternative, better suited to portable CLI tools that don't need bundled data).
 """
 
-load("//gleam/private:gleam_library.bzl", "GleamPackageInfo")
+load(":erlang_otp_tree.bzl", "find_erl_file")
+load(":gleam_library.bzl", "GleamPackageInfo")
 
 def _gleam_release_impl(ctx):
     gleam_toolchain_info = ctx.toolchains["//gleam:toolchain_type"]
@@ -22,15 +23,31 @@ def _gleam_release_impl(ctx):
     all_compiled_dirs = dep_info.transitive_compiled_dirs.to_list()
     all_data = dep_info.transitive_data.to_list()
 
-    erl_path = "erl"
-    if hasattr(erlang_toolchain, "erl_path_str") and erlang_toolchain.erl_path_str:
-        erl_path = erlang_toolchain.erl_path_str
+    ws_name = ctx.workspace_name
+    otp_tree = getattr(erlang_toolchain, "otp_tree", None)
+    extra_runfiles = []
+
+    if otp_tree:
+        # Hermetic toolchain: bundle its OTP tree so this release is genuinely portable to any
+        # machine with the same OS/CPU architecture. The toolchain's own erl_path_str is an
+        # absolute path into Bazel's own cache (e.g. ~/.cache/bazel/.../external/...), which
+        # is *not* valid on a different machine -- baking that in would produce an artifact
+        # that only ever runs on the machine that built it.
+        otp_tree_files = otp_tree[DefaultInfo].files.to_list()
+        erl_file = find_erl_file(otp_tree_files, ctx.label)
+        erl_invocation = '"$RF/{ws}/{path}"'.format(ws = ws_name, path = erl_file.short_path)
+        extra_runfiles = otp_tree_files
+    else:
+        # Local (PATH-based) toolchain: there's no bundleable tree, so fall back to a plain
+        # PATH lookup at run time -- the same portability model as gleam_binary's escript.
+        # Whatever Erlang built this must also be reasonably compatible with whatever's on
+        # PATH wherever this release actually runs.
+        erl_invocation = "erl"
 
     launcher = ctx.actions.declare_file(ctx.label.name)
 
     # At runtime, paths are relative to this launcher's own runfiles root, joined with the
     # workspace name (matching how gleam_test locates -pa paths under $TEST_SRCDIR/$WORKSPACE).
-    ws_name = ctx.workspace_name
     pa_parts = []
     for compiled_dir in all_compiled_dirs:
         pa_parts.append('-pa "$RF/{ws}/{path}/ebin"'.format(ws = ws_name, path = compiled_dir.short_path))
@@ -58,10 +75,10 @@ else
   exit 1
 fi
 
-exec "{erl_path}" {pa_flags} -noshell -s {entry_module} {entry_function} -s init stop
+exec {erl_invocation} {pa_flags} -noshell -s {entry_module} {entry_function} -s init stop
 """.format(
             label = ctx.label.name,
-            erl_path = erl_path,
+            erl_invocation = erl_invocation,
             pa_flags = pa_flags,
             entry_module = entry_module,
             entry_function = entry_function,
@@ -69,9 +86,9 @@ exec "{erl_path}" {pa_flags} -noshell -s {entry_module} {entry_function} -s init
     )
 
     # Runfiles: all transitive compiled dirs (for -pa) plus all transitive runtime data, so
-    # code can read data files at paths relative to its own package -- see the "data" attr
-    # on gleam_library for how those paths are laid out.
-    runfiles_files = all_compiled_dirs + all_data
+    # code can read data files at paths relative to its own package (see the "data" attr on
+    # gleam_library), plus the bundled OTP tree when the hermetic toolchain provided one.
+    runfiles_files = all_compiled_dirs + all_data + extra_runfiles
 
     return [
         DefaultInfo(
@@ -105,6 +122,16 @@ Packages a `gleam_library` and its transitive deps as a runfiles-tree binary: a 
 launcher script plus the compiled BEAM directories and any declared runtime `data`
 (config files, templates, certs, etc.), reachable at runtime under the launcher's own
 runfiles directory.
+
+Under the hermetic Erlang toolchain (the default), this bundles the toolchain's own OTP tree
+into the release's runfiles, so the result is genuinely portable to any machine with the same
+OS/CPU architecture -- no Erlang needs to be installed there. Under
+`gleam.local_erlang_toolchain()`'s PATH-based discovery, there is no such tree to bundle, so
+the launcher falls back to a plain PATH lookup for `erl` at run time (the same portability
+model as `gleam_binary`'s escript): whatever Erlang built this must also be reasonably
+compatible with whatever's on PATH wherever it actually runs. If you want a hard guarantee
+that this rule never silently falls back to that PATH-lookup behavior, use
+`gleam_standalone_release` instead, which fails outright unless the hermetic toolchain is active.
 
 Unlike `gleam_binary`, this does not produce a single self-contained escript -- the
 result is a launcher script that must be run alongside its `.runfiles` directory (as

--- a/gleam/private/gleam_standalone_release.bzl
+++ b/gleam/private/gleam_standalone_release.bzl
@@ -1,9 +1,11 @@
 """Implementation of the gleam_standalone_release rule.
 
 Packages a gleam_library and its transitive deps as a fully self-contained runfiles-tree
-binary that bundles the Erlang/OTP runtime itself -- unlike gleam_binary (escript) and
-gleam_release (both of which still shell out to a system Erlang), the machine that *runs*
-the result does not need any Erlang installed at all.
+binary that bundles the Erlang/OTP runtime itself -- the machine that *runs* the result does
+not need any Erlang installed at all. gleam_release does this too under the hermetic
+toolchain, but silently falls back to a PATH lookup under gleam.local_erlang_toolchain();
+this rule instead fails outright unless the hermetic toolchain is active, for callers who
+want that guaranteed rather than best-effort.
 
 Requires the hermetic Erlang toolchain, which is on by default: only that toolchain exposes a
 Bazel-visible, bundleable OTP tree (see erlang/private/hermetic_erlang_repository.bzl's
@@ -13,17 +15,8 @@ arbitrary host Erlang install's files is not reliably relocatable, since many sy
 managers bake absolute paths into generated scripts.
 """
 
+load(":erlang_otp_tree.bzl", "find_erl_file")
 load(":gleam_library.bzl", "GleamPackageInfo")
-
-def _find_erl_file(otp_tree_files, label):
-    for f in otp_tree_files:
-        if f.short_path.endswith("otp/bin/erl"):
-            return f
-    fail((
-        "gleam_standalone_release '{label}': could not find 'otp/bin/erl' in the hermetic " +
-        "Erlang toolchain's otp_tree filegroup. This is an internal error in the hermetic " +
-        "toolchain (erlang/private/hermetic_erlang_repository.bzl) -- please file an issue."
-    ).format(label = label))
 
 def _gleam_standalone_release_impl(ctx):
     gleam_toolchain_info = ctx.toolchains["//gleam:toolchain_type"]
@@ -40,7 +33,7 @@ def _gleam_standalone_release_impl(ctx):
         ).format(label = ctx.label))
 
     otp_tree_files = otp_tree[DefaultInfo].files.to_list()
-    erl_file = _find_erl_file(otp_tree_files, ctx.label)
+    erl_file = find_erl_file(otp_tree_files, ctx.label)
 
     dep_info = ctx.attr.dep[GleamPackageInfo]
     entry_module = ctx.attr.entry_module
@@ -126,14 +119,16 @@ gleam_standalone_release = rule(
     doc = """\
 Packages a `gleam_library` and its transitive deps as a fully self-contained binary that
 bundles the Erlang/OTP runtime itself: the machine that *runs* the result does not need any
-Erlang installed at all, unlike `gleam_binary` (escript) or `gleam_release`, both of which
-still shell out to a system Erlang.
+Erlang installed at all, unlike `gleam_binary` (escript), which always shells out to a system
+Erlang via a PATH lookup.
 
-Requires the hermetic Erlang toolchain, which is on by default -- fails with an actionable
-error if `gleam.local_erlang_toolchain()` has opted back out to PATH-based discovery. This is
-the recommended, easiest-to-get-right way to ship a portable Gleam CLI tool: build once, copy
-the resulting runfiles tree to any machine with the same OS/CPU architecture, and run it with
-no setup required.
+`gleam_release` also bundles the runtime under the hermetic toolchain, but silently falls
+back to a PATH lookup under `gleam.local_erlang_toolchain()`. This rule instead requires the
+hermetic Erlang toolchain (on by default) and fails with an actionable error if
+`gleam.local_erlang_toolchain()` has opted back out to PATH-based discovery -- use this when
+you want that guarantee enforced rather than best-effort. Build once, copy the resulting
+runfiles tree to any machine with the same OS/CPU architecture, and run it with no setup
+required.
 
 Like `gleam_release`, this does not attempt to start the package as an OTP application (no
 `application:ensure_all_started` call) -- call it yourself from `entry_module` if needed.


### PR DESCRIPTION
## Summary

Follow-up to PR #84's discovery: `gleam_release`'s launcher baked in the Erlang toolchain's `erl_path_str` directly. Under the hermetic toolchain (the default now), that's an absolute path into Bazel's own cache (`~/.cache/bazel/.../external/...`) -- valid on the machine that built it, and *nowhere else*. An artifact that only runs on the machine that built it isn't actually useful.

### The fix

`gleam_release` now mirrors `gleam_standalone_release`: when the hermetic toolchain provides an `otp_tree`, it bundles those files into its own runfiles and execs a runfiles-relative `erl` path instead of the toolchain's absolute one. Only when `gleam.local_erlang_toolchain()` opts out (no bundleable tree exists) does it fall back to a plain PATH lookup -- the same portability model `gleam_binary`'s escript already had (needs a compatible Erlang present wherever it runs, but at least doesn't depend on one specific absolute path that's essentially guaranteed not to exist on a different machine).

Extracted the `otp/bin/erl`-finding logic (previously duplicated) into a new shared `gleam/private/erlang_otp_tree.bzl`.

`gleam_standalone_release` keeps a distinct, meaningful purpose: it fails outright if the hermetic toolchain isn't active, rather than `gleam_release`'s best-effort fallback -- for callers who want that guaranteed rather than silently degrading to a less-portable artifact.

### Stronger CI verification: a genuinely fresh, Erlang-free machine

The previous `env -i PATH=` trick for `examples/standalone_cli` only proved "no Erlang currently on *this* machine's PATH" -- it couldn't fully rule out something silently depending on this machine's own filesystem state. Replaced it (and added the same for `examples/web_service`'s `gleam_release` binary) with a real cross-machine test: copy the actual build output onto a genuinely fresh Docker container that never had Erlang installed at all, then run it there and check the output.

The copy step (`cp -L`) dereferences every runfiles symlink into real file contents first, so the copied artifact has no dependency on this machine's Bazel cache either -- it's a true standalone copy, not just "the same symlinks pointed somewhere new."

## Test plan

- [x] All touched `.bzl`/`.yaml` files parse cleanly (Python-AST / PyYAML sanity checks); no Bazel or the exact Docker/Bazel interaction available to test in this sandbox.
- [ ] CI: confirm `examples/web_service`'s existing e2e test still passes (still uses the toolchain's runfiles-bundling path, now via the shared helper), and that both new Docker-based verification steps (`standalone_cli`, `web_service`) succeed against a container that never had Erlang installed.


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_