### PR TITLE
Add a Starlark analysistest/unittest layer, plus a real-failure fixture

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,14 @@ jobs:
           key: bazel-cache-${{ matrix.os }}-${{ matrix.bazel-version }}-bzlmod-${{ matrix.bzlmod-enabled }}-${{ hashFiles('**/MODULE.bazel', '**/WORKSPACE') }}
           restore-keys: |
             bazel-cache-${{ matrix.os }}-${{ matrix.bazel-version }}-bzlmod-${{ matrix.bzlmod-enabled }}-
+      - name: Run Bazel Unit Tests - test/unit (Starlark analysistest/unittest)
+        run: |
+          echo "Running Starlark unit tests for private rule/module-extension helpers"
+          if ${{ matrix.bzlmod-enabled }}; then
+            bazel test --enable_bzlmod --noenable_workspace --test_output=errors //test/...
+          else
+            bazel test --noenable_bzlmod --enable_workspace --test_output=errors //test/...
+          fi
       - name: Run Bazel Tests - gleam_gazelle Directory (Gazelle language extension)
         run: |
           echo "Running the gleam Gazelle language extension's Go unit tests"
@@ -161,6 +169,42 @@ jobs:
           else
             bazel test --noenable_bzlmod --enable_workspace --test_output=errors //...
           fi
+      - name: Run Bazel Build - examples/expect_fail Directory
+        working-directory: examples/expect_fail
+        run: |
+          echo "Building examples/expect_fail directory with bzlmod=${{ matrix.bzlmod-enabled }}"
+          if ${{ matrix.bzlmod-enabled }}; then
+            bazel build --enable_bzlmod --noenable_workspace //...
+          else
+            bazel build --noenable_bzlmod --enable_workspace //...
+          fi
+      - name: Verify gleam_test/gleam_format_test detect real failures (examples/expect_fail)
+        working-directory: examples/expect_fail
+        run: |
+          # Every other example only shows the happy path. These two targets are deliberately
+          # broken (see examples/expect_fail/README.md), so `bazel test` on them must fail --
+          # if either one unexpectedly passes, gleam_test/gleam_format_test have stopped
+          # actually detecting failures, which every other example in this repo would miss.
+          if ${{ matrix.bzlmod-enabled }}; then
+            if bazel test --enable_bzlmod --noenable_workspace --test_output=errors //:expect_fail_test; then
+              echo "FAIL: //:expect_fail_test is deliberately broken but bazel test reported success" >&2
+              exit 1
+            fi
+            if bazel test --enable_bzlmod --noenable_workspace --test_output=errors //:expect_fail_format_test; then
+              echo "FAIL: //:expect_fail_format_test is deliberately misformatted but bazel test reported success" >&2
+              exit 1
+            fi
+          else
+            if bazel test --noenable_bzlmod --enable_workspace --test_output=errors //:expect_fail_test; then
+              echo "FAIL: //:expect_fail_test is deliberately broken but bazel test reported success" >&2
+              exit 1
+            fi
+            if bazel test --noenable_bzlmod --enable_workspace --test_output=errors //:expect_fail_format_test; then
+              echo "FAIL: //:expect_fail_format_test is deliberately misformatted but bazel test reported success" >&2
+              exit 1
+            fi
+          fi
+          echo "PASS: gleam_test and gleam_format_test both correctly detected their intentionally-broken fixtures"
       - name: Run Bazel Build - examples/hello_world Directory
         working-directory: examples/hello_world
         run: |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ These rules are early-stage. In particular:
   PATH-based host discovery entirely with `gleam.local_erlang_toolchain()` (see
   [examples/nested_smoke](examples/nested_smoke)) if hermetic downloads aren't practical in
   your build environment.
-- **Test coverage is currently limited to basic end-to-end examples** (see `examples/`) rather
-  than a full unit test suite for the rule implementations themselves.
+- **Test coverage is primarily end-to-end examples** (see `examples/`), plus a growing
+  `test/unit/` suite of Starlark `analysistest`/`unittest` tests (bazel-skylib) for private
+  rule/module-extension logic that's awkward to exercise through a full build --
+  [examples/expect_fail](examples/expect_fail) additionally proves `gleam_test` and
+  `gleam_format_test` actually detect real failures, not just happy-path input.
 - `gleam_binary` (escript) always requires a compatible Erlang runtime to be present on the
   machine that _runs_ the resulting executable: its `#!/usr/bin/env escript` shebang finds
   `escript` via `PATH` at _run_ time, separately from whichever Erlang/OTP built it (the

--- a/examples/expect_fail/BUILD.bazel
+++ b/examples/expect_fail/BUILD.bazel
@@ -13,17 +13,17 @@ load("@rules_gleam//gleam:defs.bzl", "gleam_format_test", "gleam_library", "glea
 
 gleam_library(
     name = "expect_fail_fixture_lib",
+    package_name = "expect_fail_fixture",
     srcs = glob(["src/**/*.gleam"]),
     data = ["gleam.toml"],
-    package_name = "expect_fail_fixture",
     deps = ["@gleam_packages//:gleam_stdlib"],
 )
 
 gleam_test(
     name = "expect_fail_test",
+    package_name = "expect_fail_fixture",
     srcs = glob(["src/**/*.gleam"]),
     data = ["gleam.toml"],
-    package_name = "expect_fail_fixture",
     test_srcs = glob(["test/**/*.gleam"]),
     deps = [
         "@gleam_packages//:gleam_stdlib",

--- a/examples/expect_fail/BUILD.bazel
+++ b/examples/expect_fail/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_gleam//gleam:defs.bzl", "gleam_format_test", "gleam_library", "gleam_test")
+
+# Intentionally-broken fixtures.
+#
+# Every other example in this repo only shows the happy path (tests passing, files already
+# formatted). These two targets are DELIBERATELY failing -- expect_fail_test asserts a value
+# that greeting() never returns, and bad_format.gleam is deliberately misformatted -- to prove
+# gleam_test/gleam_format_test actually detect real failures instead of silently passing.
+#
+# CI runs these explicitly and asserts `bazel test` reports failure; see
+# .github/workflows/ci.yaml's "Verify gleam_test/gleam_format_test detect real failures" step.
+# Neither target is meant to be swept up by a plain `bazel test //...` here.
+
+gleam_library(
+    name = "expect_fail_fixture_lib",
+    srcs = glob(["src/**/*.gleam"]),
+    data = ["gleam.toml"],
+    package_name = "expect_fail_fixture",
+    deps = ["@gleam_packages//:gleam_stdlib"],
+)
+
+gleam_test(
+    name = "expect_fail_test",
+    srcs = glob(["src/**/*.gleam"]),
+    data = ["gleam.toml"],
+    package_name = "expect_fail_fixture",
+    test_srcs = glob(["test/**/*.gleam"]),
+    deps = [
+        "@gleam_packages//:gleam_stdlib",
+        "@gleam_packages//:gleeunit",
+    ],
+)
+
+gleam_format_test(
+    name = "expect_fail_format_test",
+    srcs = ["bad_format.gleam"],
+)

--- a/examples/expect_fail/MODULE.bazel
+++ b/examples/expect_fail/MODULE.bazel
@@ -1,0 +1,28 @@
+bazel_dep(name = "muchq_rules_gleam", version = "0.0.1", repo_name = "rules_gleam")
+local_path_override(
+    module_name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+gleam = use_extension("@rules_gleam//gleam:extensions.bzl", "gleam")
+gleam.toolchain(version = "1.14.0")
+gleam.hex_package(
+    name = "gleam_stdlib",
+    sha256 = "621d600bb134bc239cb2537630899817b1a42e60a1d46c5e9f3fae39f88c800b",
+    version = "0.60.0",
+    deps = [],
+)
+gleam.hex_package(
+    name = "gleeunit",
+    sha256 = "da9553ce58b67924b3c631f96fe3370c49eb6d6dc6b384ec4862cc4aaa718f3c",
+    version = "1.9.0",
+    deps = ["gleam_stdlib"],
+)
+use_repo(gleam, "gleam_packages", "gleam_toolchains", "local_config_erlang")
+
+register_toolchains("@gleam_toolchains//:all")
+
+register_toolchains("@local_config_erlang//:erlang_toolchain_definition")

--- a/examples/expect_fail/README.md
+++ b/examples/expect_fail/README.md
@@ -1,0 +1,13 @@
+# expect_fail
+
+Every other example in this repo demonstrates the happy path: tests passing, files already
+formatted. This one is deliberately broken, on purpose:
+
+- `expect_fail_test` (a `gleam_test`) asserts a value `greeting()` never returns.
+- `expect_fail_format_test` (a `gleam_format_test`) checks `bad_format.gleam`, which is
+  deliberately misformatted.
+
+Both targets are expected to make `bazel test` fail. CI runs them explicitly and asserts that
+failure actually happens (see the `.github/workflows/ci.yaml` step for this directory), proving
+`gleam_test`/`gleam_format_test` correctly detect real failures rather than only ever being
+exercised against inputs that already pass.

--- a/examples/expect_fail/WORKSPACE.bazel
+++ b/examples/expect_fail/WORKSPACE.bazel
@@ -1,0 +1,19 @@
+# Override http_archive for local testing
+local_repository(
+    name = "muchq_rules_gleam",
+    path = "../..",
+)
+
+#---SNIP--- Below here is re-used in the workspace snippet published on releases
+
+######################
+# rules_gleam setup #
+######################
+# Fetches the rules_gleam dependencies.
+# If you want to have a different version of some dependency,
+# you should fetch it *before* calling this.
+# Alternatively, you can skip calling this function, so long as you've
+# already fetched all the dependencies.
+load("@muchq_rules_gleam//gleam:repositories.bzl", "rules_gleam_dependencies")
+
+rules_gleam_dependencies()

--- a/examples/expect_fail/bad_format.gleam
+++ b/examples/expect_fail/bad_format.gleam
@@ -1,0 +1,3 @@
+pub fn bad_formatting() -> String {
+                              "this file is deliberately misformatted"
+}

--- a/examples/expect_fail/gleam.toml
+++ b/examples/expect_fail/gleam.toml
@@ -1,0 +1,8 @@
+name = "expect_fail_fixture"
+version = "0.1.0"
+
+[dependencies]
+gleam_stdlib = "~> 0.60 or ~> 0.68 or ~> 0.69"
+
+[dev-dependencies]
+gleeunit = "~> 1.0"

--- a/examples/expect_fail/src/my_app.gleam
+++ b/examples/expect_fail/src/my_app.gleam
@@ -1,0 +1,3 @@
+pub fn greeting() -> String {
+  "Hello from my_app!"
+}

--- a/examples/expect_fail/test/my_app_test.gleam
+++ b/examples/expect_fail/test/my_app_test.gleam
@@ -1,0 +1,15 @@
+import gleeunit
+import gleeunit/should
+import my_app
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// Deliberately wrong: my_app.greeting() never returns this string. This assertion exists to
+// prove gleam_test actually fails `bazel test` on a genuinely failing test, rather than only
+// ever being exercised on happy-path examples elsewhere in this repo.
+pub fn greeting_test() {
+  my_app.greeting()
+  |> should.equal("This assertion is deliberately wrong.")
+}

--- a/gleam/BUILD.bazel
+++ b/gleam/BUILD.bazel
@@ -54,6 +54,7 @@ bzl_library(
     deps = [
         ":repositories",
         "//gleam/private:manifest_toml",
+        "//gleam/private:version",
     ],
 )
 

--- a/gleam/extensions.bzl
+++ b/gleam/extensions.bzl
@@ -44,6 +44,7 @@ gleam.hex_manifest(manifest = "//path/to:manifest.toml")
 load("//erlang/private:hermetic_erlang_repository.bzl", "hermetic_erlang_repository")  # buildifier: disable=bzl-visibility
 load("//erlang/private:local_erlang_repository.bzl", "local_erlang_repository")  # buildifier: disable=bzl-visibility
 load("//gleam/private:manifest_toml.bzl", "parse_manifest_toml")
+load("//gleam/private:version.bzl", "parse_version")
 load(":repositories.bzl", "gleam_register_toolchains")
 
 _DEFAULT_NAME = "gleam"
@@ -121,25 +122,6 @@ path-sourced packages are skipped with a printed warning, since only Hex-hosted 
 supported.
 """, allow_single_file = True, mandatory = True),
 })
-
-def _parse_version(version):
-    """Parses a version string into a list of integers for comparison."""
-    parts = []
-    for part in version.split("."):
-        num = ""
-
-        # iterate directly over characters
-        for i in range(len(part)):
-            char = part[i]
-            if char.isdigit():
-                num += char
-            else:
-                break
-        if num:
-            parts.append(int(num))
-        else:
-            parts.append(0)
-    return parts
 
 def _toolchain_extension(module_ctx):
     registrations = {}
@@ -229,7 +211,7 @@ def _toolchain_extension(module_ctx):
     # Register Gleam toolchains.
     for name, versions in registrations.items():
         if len(versions) > 1:
-            selected = sorted(versions, key = _parse_version, reverse = True)[0]
+            selected = sorted(versions, key = parse_version, reverse = True)[0]
 
             # buildifier: disable=print
             print("NOTE: gleam toolchain {} has multiple versions {}, selected {}".format(name, versions, selected))

--- a/gleam/private/BUILD.bazel
+++ b/gleam/private/BUILD.bazel
@@ -87,3 +87,9 @@ bzl_library(
     srcs = ["manifest_toml.bzl"],
     visibility = ["//gleam:__subpackages__"],
 )
+
+bzl_library(
+    name = "version",
+    srcs = ["version.bzl"],
+    visibility = ["//gleam:__subpackages__"],
+)

--- a/gleam/private/erlang_otp_tree.bzl
+++ b/gleam/private/erlang_otp_tree.bzl
@@ -5,6 +5,8 @@ Used by gleam_release (when the hermetic toolchain is active) and gleam_standalo
 filegroup -- see erlang/private/hermetic_erlang_repository.bzl.
 """
 
+visibility(["//gleam/...", "//test/..."])
+
 def find_erl_file(otp_tree_files, label):
     """Returns the `otp/bin/erl` File within a hermetic toolchain's otp_tree filegroup files.
 

--- a/gleam/private/erlang_otp_tree.bzl
+++ b/gleam/private/erlang_otp_tree.bzl
@@ -27,3 +27,30 @@ def find_erl_file(otp_tree_files, label):
         "filegroup. This is an internal error in the hermetic toolchain " +
         "(erlang/private/hermetic_erlang_repository.bzl) -- please file an issue."
     ).format(label = label))
+
+def resolve_erl_invocation(otp_tree_files, ws_name, label):
+    """Returns (erl_invocation, extra_runfiles) for a gleam_release-style launcher script.
+
+    If `otp_tree_files` is non-empty (the hermetic Erlang toolchain provided a bundleable OTP
+    tree), returns a runfiles-relative path to its "otp/bin/erl", quoted and ready to splice
+    into a shell command, so the launcher never depends on anything outside its own runfiles --
+    the toolchain's own absolute path is a build-machine-only location (e.g. under Bazel's
+    cache) and would silently break on any other machine. Otherwise falls back to a plain "erl"
+    PATH lookup, and no extra runfiles are needed.
+
+    Args:
+      otp_tree_files: list of File, the hermetic toolchain's otp_tree filegroup files, or an
+        empty list if the toolchain has no bundleable tree.
+      ws_name: str, the workspace name the launcher's runfiles are rooted under.
+      label: Label of the rule doing the lookup, used only for find_erl_file's error message.
+
+    Returns:
+      A (erl_invocation, extra_runfiles) tuple: erl_invocation is a shell-ready string (already
+      quoted if it's a runfiles path); extra_runfiles is the list of File to add to the
+      launcher's runfiles (empty if falling back to PATH).
+    """
+    if not otp_tree_files:
+        return "erl", []
+    erl_file = find_erl_file(otp_tree_files, label)
+    erl_invocation = '"$RF/{ws}/{path}"'.format(ws = ws_name, path = erl_file.short_path)
+    return erl_invocation, otp_tree_files

--- a/gleam/private/gleam_release.bzl
+++ b/gleam/private/gleam_release.bzl
@@ -9,7 +9,7 @@ runtime data available alongside the compiled code (see gleam_binary for the sin
 escript alternative, better suited to portable CLI tools that don't need bundled data).
 """
 
-load(":erlang_otp_tree.bzl", "find_erl_file")
+load(":erlang_otp_tree.bzl", "resolve_erl_invocation")
 load(":gleam_library.bzl", "GleamPackageInfo")
 
 def _gleam_release_impl(ctx):
@@ -25,24 +25,14 @@ def _gleam_release_impl(ctx):
 
     ws_name = ctx.workspace_name
     otp_tree = getattr(erlang_toolchain, "otp_tree", None)
-    extra_runfiles = []
+    otp_tree_files = otp_tree[DefaultInfo].files.to_list() if otp_tree else []
 
-    if otp_tree:
-        # Hermetic toolchain: bundle its OTP tree so this release is genuinely portable to any
-        # machine with the same OS/CPU architecture. The toolchain's own erl_path_str is an
-        # absolute path into Bazel's own cache (e.g. ~/.cache/bazel/.../external/...), which
-        # is *not* valid on a different machine -- baking that in would produce an artifact
-        # that only ever runs on the machine that built it.
-        otp_tree_files = otp_tree[DefaultInfo].files.to_list()
-        erl_file = find_erl_file(otp_tree_files, ctx.label)
-        erl_invocation = '"$RF/{ws}/{path}"'.format(ws = ws_name, path = erl_file.short_path)
-        extra_runfiles = otp_tree_files
-    else:
-        # Local (PATH-based) toolchain: there's no bundleable tree, so fall back to a plain
-        # PATH lookup at run time -- the same portability model as gleam_binary's escript.
-        # Whatever Erlang built this must also be reasonably compatible with whatever's on
-        # PATH wherever this release actually runs.
-        erl_invocation = "erl"
+    # See resolve_erl_invocation's docstring for why the hermetic toolchain's own erl_path_str
+    # can't be used directly here: it's an absolute path into Bazel's own cache, not valid on
+    # any machine but the one that built this release. This branch (and its counterpart, the
+    # PATH-based fallback when the toolchain has no bundleable otp_tree) is covered directly by
+    # test/unit/erlang_otp_tree, without needing a full toolchain-dependent build to exercise.
+    erl_invocation, extra_runfiles = resolve_erl_invocation(otp_tree_files, ws_name, ctx.label)
 
     launcher = ctx.actions.declare_file(ctx.label.name)
 

--- a/gleam/private/manifest_toml.bzl
+++ b/gleam/private/manifest_toml.bzl
@@ -13,6 +13,8 @@ plain string scanning (Starlark has no regex engine and repository/module contex
 cannot be iterated directly, only indexed).
 """
 
+visibility(["//gleam/...", "//test/..."])
+
 def _extract_string(line, key):
     """Returns the value of `key = "..."` in `line`, or None if `key` isn't present."""
     marker = key + " = \""

--- a/gleam/private/package_name_check.bzl
+++ b/gleam/private/package_name_check.bzl
@@ -6,6 +6,8 @@ package is built or tested, without adding its output to the package's default o
 slowing down the critical path.
 """
 
+visibility(["//gleam/...", "//test/..."])
+
 def _gleam_package_name_check_impl(ctx):
     marker = ctx.actions.declare_file(ctx.label.name + ".ok")
     ctx.actions.run_shell(

--- a/gleam/private/version.bzl
+++ b/gleam/private/version.bzl
@@ -1,0 +1,34 @@
+"""Version-string comparison used to pick the highest of several toolchain version pins.
+
+Extracted from gleam/extensions.bzl so it can be unit tested directly: module extension logic
+itself isn't testable via analysistest (which only exercises rule() targets resolved during the
+analysis phase), but a plain Starlark function like this one is -- see test/unit/version.
+"""
+
+def parse_version(version):
+    """Parses a dotted version string into a list of ints for numeric comparison.
+
+    Each dot-separated component is read only up to its first non-digit character, so a
+    prerelease-style suffix like "0-rc1" parses as plain 0; an empty or all-non-digit
+    component also parses as 0.
+
+    Args:
+      version: a dotted version string, e.g. "1.14.0" or "2.0.0-rc1".
+
+    Returns:
+      A list of ints, one per dot-separated component, suitable as a sort key.
+    """
+    parts = []
+    for part in version.split("."):
+        num = ""
+        for i in range(len(part)):
+            char = part[i]
+            if char.isdigit():
+                num += char
+            else:
+                break
+        if num:
+            parts.append(int(num))
+        else:
+            parts.append(0)
+    return parts

--- a/gleam/private/version.bzl
+++ b/gleam/private/version.bzl
@@ -5,6 +5,8 @@ itself isn't testable via analysistest (which only exercises rule() targets reso
 analysis phase), but a plain Starlark function like this one is -- see test/unit/version.
 """
 
+visibility(["//gleam/...", "//test/..."])
+
 def parse_version(version):
     """Parses a dotted version string into a list of ints for numeric comparison.
 

--- a/test/unit/erlang_otp_tree/BUILD.bazel
+++ b/test/unit/erlang_otp_tree/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":erlang_otp_tree_test.bzl", "erlang_otp_tree_test_suite")
+
+erlang_otp_tree_test_suite(name = "erlang_otp_tree_test_suite")

--- a/test/unit/erlang_otp_tree/dummy.txt
+++ b/test/unit/erlang_otp_tree/dummy.txt
@@ -1,0 +1,1 @@
+A fixture file that deliberately does not look like otp/bin/erl.

--- a/test/unit/erlang_otp_tree/erlang_otp_tree_test.bzl
+++ b/test/unit/erlang_otp_tree/erlang_otp_tree_test.bzl
@@ -1,0 +1,100 @@
+"""Unit tests for gleam/private/erlang_otp_tree.bzl.
+
+Covers the exact branching logic that regressed in gleam_release before it was extracted here
+(PR #85): whether the hermetic toolchain's otp_tree is present or absent decides between a
+runfiles-relative erl path and a plain PATH lookup, and that decision needs to keep being
+right without requiring a full toolchain-dependent build to check it.
+"""
+
+load("@bazel_skylib//lib:analysistest.bzl", "analysistest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//gleam/private:erlang_otp_tree.bzl", "find_erl_file", "resolve_erl_invocation")
+
+def _fake_file(short_path):
+    # find_erl_file and resolve_erl_invocation only ever read `.short_path` off these, so a
+    # plain struct stands in for a real ctx.actions.File without needing any Bazel machinery.
+    return struct(short_path = short_path)
+
+# ---- Pure-function tests: no target-under-test or toolchain resolution needed. ----
+
+def _finds_erl_in_otp_tree_test_impl(ctx):
+    env = unittest.begin(ctx)
+    files = [
+        _fake_file("external/foo/otp/bin/erlc"),
+        _fake_file("external/foo/otp/bin/erl"),
+        _fake_file("external/foo/otp/lib/kernel.beam"),
+    ]
+    found = find_erl_file(files, Label("//test/unit/erlang_otp_tree:fake"))
+    asserts.equals(env, "external/foo/otp/bin/erl", found.short_path)
+    return unittest.end(env)
+
+finds_erl_in_otp_tree_test = unittest.make(_finds_erl_in_otp_tree_test_impl)
+
+def _falls_back_to_path_when_no_otp_tree_test_impl(ctx):
+    env = unittest.begin(ctx)
+    invocation, extra_runfiles = resolve_erl_invocation([], "my_ws", Label("//test/unit/erlang_otp_tree:fake"))
+    asserts.equals(env, "erl", invocation)
+    asserts.equals(env, [], extra_runfiles)
+    return unittest.end(env)
+
+falls_back_to_path_when_no_otp_tree_test = unittest.make(_falls_back_to_path_when_no_otp_tree_test_impl)
+
+def _bundles_runfiles_relative_path_when_otp_tree_present_test_impl(ctx):
+    env = unittest.begin(ctx)
+    files = [_fake_file("external/foo/otp/bin/erl")]
+    invocation, extra_runfiles = resolve_erl_invocation(files, "my_ws", Label("//test/unit/erlang_otp_tree:fake"))
+
+    # This exact shape is what gleam_release got wrong before PR #85: it must be a
+    # runfiles-relative path (quoted, joined with $RF and the workspace name), never the
+    # toolchain's own absolute build-machine path.
+    asserts.equals(env, '"$RF/my_ws/external/foo/otp/bin/erl"', invocation)
+    asserts.equals(env, files, extra_runfiles)
+    return unittest.end(env)
+
+bundles_runfiles_relative_path_when_otp_tree_present_test = unittest.make(_bundles_runfiles_relative_path_when_otp_tree_present_test_impl)
+
+# ---- analysistest.expect_failure: proves find_erl_file's fail() actually fires, through a
+# real rule and real Bazel File objects (rather than the fakes above). ----
+
+def _lookup_impl(ctx):
+    find_erl_file(ctx.files.srcs, ctx.label)
+    return [DefaultInfo()]
+
+_lookup_rule = rule(
+    implementation = _lookup_impl,
+    attrs = {"srcs": attr.label_list(allow_files = True)},
+)
+
+def _fails_when_erl_absent_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    analysistest.expect_failure(env, "could not find 'otp/bin/erl'")
+    return analysistest.end(env)
+
+_fails_when_erl_absent_test = analysistest.make(_fails_when_erl_absent_test_impl, expect_failure = True)
+
+def _test_fails_when_erl_absent():
+    _lookup_rule(
+        name = "otp_tree_missing_erl",
+        srcs = ["dummy.txt"],
+        tags = ["manual"],
+    )
+    _fails_when_erl_absent_test(
+        name = "fails_when_erl_absent_test",
+        target_under_test = ":otp_tree_missing_erl",
+    )
+
+def erlang_otp_tree_test_suite(name):
+    _test_fails_when_erl_absent()
+    unittest.suite(
+        "erlang_otp_tree_pure_tests",
+        finds_erl_in_otp_tree_test,
+        falls_back_to_path_when_no_otp_tree_test,
+        bundles_runfiles_relative_path_when_otp_tree_present_test,
+    )
+    native.test_suite(
+        name = name,
+        tests = [
+            ":erlang_otp_tree_pure_tests",
+            ":fails_when_erl_absent_test",
+        ],
+    )

--- a/test/unit/erlang_otp_tree/erlang_otp_tree_test.bzl
+++ b/test/unit/erlang_otp_tree/erlang_otp_tree_test.bzl
@@ -6,8 +6,7 @@ runfiles-relative erl path and a plain PATH lookup, and that decision needs to k
 right without requiring a full toolchain-dependent build to check it.
 """
 
-load("@bazel_skylib//lib:analysistest.bzl", "analysistest")
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("//gleam/private:erlang_otp_tree.bzl", "find_erl_file", "resolve_erl_invocation")
 
 def _fake_file(short_path):

--- a/test/unit/erlang_otp_tree/erlang_otp_tree_test.bzl
+++ b/test/unit/erlang_otp_tree/erlang_otp_tree_test.bzl
@@ -7,7 +7,7 @@ right without requiring a full toolchain-dependent build to check it.
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
-load("//gleam/private:erlang_otp_tree.bzl", "find_erl_file", "resolve_erl_invocation")
+load("//gleam/private:erlang_otp_tree.bzl", "find_erl_file", "resolve_erl_invocation")  # buildifier: disable=bzl-visibility
 
 def _fake_file(short_path):
     # find_erl_file and resolve_erl_invocation only ever read `.short_path` off these, so a
@@ -52,8 +52,9 @@ def _bundles_runfiles_relative_path_when_otp_tree_present_test_impl(ctx):
 
 bundles_runfiles_relative_path_when_otp_tree_present_test = unittest.make(_bundles_runfiles_relative_path_when_otp_tree_present_test_impl)
 
-# ---- analysistest.expect_failure: proves find_erl_file's fail() actually fires, through a
-# real rule and real Bazel File objects (rather than the fakes above). ----
+# ---- asserts.expect_failure (via analysistest.make(expect_failure = True)): proves
+# find_erl_file's fail() actually fires, through a real rule and real Bazel File objects
+# (rather than the fakes above). ----
 
 def _lookup_impl(ctx):
     find_erl_file(ctx.files.srcs, ctx.label)
@@ -66,7 +67,7 @@ _lookup_rule = rule(
 
 def _fails_when_erl_absent_test_impl(ctx):
     env = analysistest.begin(ctx)
-    analysistest.expect_failure(env, "could not find 'otp/bin/erl'")
+    asserts.expect_failure(env, "could not find 'otp/bin/erl'")
     return analysistest.end(env)
 
 _fails_when_erl_absent_test = analysistest.make(_fails_when_erl_absent_test_impl, expect_failure = True)

--- a/test/unit/manifest_toml/BUILD.bazel
+++ b/test/unit/manifest_toml/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":manifest_toml_test.bzl", "manifest_toml_test_suite")
+
+manifest_toml_test_suite(name = "manifest_toml_test_suite")

--- a/test/unit/manifest_toml/manifest_toml_test.bzl
+++ b/test/unit/manifest_toml/manifest_toml_test.bzl
@@ -1,7 +1,7 @@
 """Unit tests for gleam/private/manifest_toml.bzl's parse_manifest_toml."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//gleam/private:manifest_toml.bzl", "parse_manifest_toml")
+load("//gleam/private:manifest_toml.bzl", "parse_manifest_toml")  # buildifier: disable=bzl-visibility
 
 _SAMPLE = """
 packages = [

--- a/test/unit/manifest_toml/manifest_toml_test.bzl
+++ b/test/unit/manifest_toml/manifest_toml_test.bzl
@@ -1,0 +1,67 @@
+"""Unit tests for gleam/private/manifest_toml.bzl's parse_manifest_toml."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//gleam/private:manifest_toml.bzl", "parse_manifest_toml")
+
+_SAMPLE = """
+packages = [
+  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
+  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "local_thing", version = "0.1.0", build_tools = ["gleam"], requirements = [], otp_app = "local_thing", source = "local" },
+]
+"""
+
+def _parses_hex_package_test_impl(ctx):
+    env = unittest.begin(ctx)
+    packages = parse_manifest_toml(_SAMPLE)
+    asserts.equals(env, 3, len(packages))
+
+    stdlib = packages[0]
+    asserts.equals(env, "gleam_stdlib", stdlib.name)
+    asserts.equals(env, "0.60.0", stdlib.version)
+    asserts.equals(env, "hex", stdlib.source)
+    asserts.equals(env, "621d600bb134bc239cb2537630899817b1a42e60a1d46c5e9f3fae39f88c800b", stdlib.sha256)
+    asserts.equals(env, [], stdlib.deps)
+    return unittest.end(env)
+
+parses_hex_package_test = unittest.make(_parses_hex_package_test_impl)
+
+def _parses_requirements_as_deps_test_impl(ctx):
+    env = unittest.begin(ctx)
+    packages = parse_manifest_toml(_SAMPLE)
+    gleeunit = packages[1]
+    asserts.equals(env, "gleeunit", gleeunit.name)
+    asserts.equals(env, ["gleam_stdlib"], gleeunit.deps)
+    return unittest.end(env)
+
+parses_requirements_as_deps_test = unittest.make(_parses_requirements_as_deps_test_impl)
+
+def _non_hex_source_has_empty_checksum_test_impl(ctx):
+    env = unittest.begin(ctx)
+    packages = parse_manifest_toml(_SAMPLE)
+    local_pkg = packages[2]
+
+    # extensions.bzl's caller is responsible for skipping non-"hex" packages; this function
+    # just needs to parse whatever source is declared and not require a checksum for it.
+    asserts.equals(env, "local", local_pkg.source)
+    asserts.equals(env, "", local_pkg.sha256)
+    return unittest.end(env)
+
+non_hex_source_has_empty_checksum_test = unittest.make(_non_hex_source_has_empty_checksum_test_impl)
+
+def _empty_manifest_parses_to_no_packages_test_impl(ctx):
+    env = unittest.begin(ctx)
+    packages = parse_manifest_toml("packages = [\n]\n")
+    asserts.equals(env, 0, len(packages))
+    return unittest.end(env)
+
+empty_manifest_parses_to_no_packages_test = unittest.make(_empty_manifest_parses_to_no_packages_test_impl)
+
+def manifest_toml_test_suite(name):
+    unittest.suite(
+        name,
+        parses_hex_package_test,
+        parses_requirements_as_deps_test,
+        non_hex_source_has_empty_checksum_test,
+        empty_manifest_parses_to_no_packages_test,
+    )

--- a/test/unit/package_name_check/BUILD.bazel
+++ b/test/unit/package_name_check/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":package_name_check_test.bzl", "package_name_check_test_suite")
+
+package_name_check_test_suite(name = "package_name_check_test_suite")

--- a/test/unit/package_name_check/fixture_gleam.toml
+++ b/test/unit/package_name_check/fixture_gleam.toml
@@ -1,0 +1,2 @@
+name = "my_pkg"
+version = "0.1.0"

--- a/test/unit/package_name_check/package_name_check_test.bzl
+++ b/test/unit/package_name_check/package_name_check_test.bzl
@@ -1,0 +1,54 @@
+"""Unit test for gleam/private/package_name_check.bzl's gleam_package_name_check rule.
+
+gleam_package_name_check has no toolchain dependency, so its registered action can be
+inspected directly via analysistest without needing a real Gleam/Erlang toolchain build.
+"""
+
+load("@bazel_skylib//lib:analysistest.bzl", "analysistest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts")
+load("//gleam/private:package_name_check.bzl", "gleam_package_name_check")
+
+def _registers_validation_action_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    actions = analysistest.target_actions(env)
+    asserts.equals(env, 1, len(actions))
+
+    action = actions[0]
+    asserts.equals(env, "GleamPackageNameCheck", action.mnemonic)
+
+    input_short_paths = [f.short_path for f in action.inputs.to_list()]
+    asserts.true(
+        env,
+        any([p.endswith("fixture_gleam.toml") for p in input_short_paths]),
+        "expected fixture_gleam.toml among the action's inputs, got: {}".format(input_short_paths),
+    )
+
+    output_short_paths = [f.short_path for f in action.outputs.to_list()]
+    asserts.true(
+        env,
+        any([p.endswith(".ok") for p in output_short_paths]),
+        "expected a '*.ok' marker among the action's outputs, got: {}".format(output_short_paths),
+    )
+
+    return analysistest.end(env)
+
+registers_validation_action_test = analysistest.make(_registers_validation_action_test_impl)
+
+def _test_registers_validation_action():
+    gleam_package_name_check(
+        name = "check_under_test",
+        gleam_toml = "fixture_gleam.toml",
+        package_name = "my_pkg",
+        tags = ["manual"],
+    )
+    registers_validation_action_test(
+        name = "registers_validation_action_test",
+        target_under_test = ":check_under_test",
+    )
+
+def package_name_check_test_suite(name):
+    _test_registers_validation_action()
+    native.test_suite(
+        name = name,
+        tests = [":registers_validation_action_test"],
+    )

--- a/test/unit/package_name_check/package_name_check_test.bzl
+++ b/test/unit/package_name_check/package_name_check_test.bzl
@@ -5,7 +5,7 @@ inspected directly via analysistest without needing a real Gleam/Erlang toolchai
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//gleam/private:package_name_check.bzl", "gleam_package_name_check")
+load("//gleam/private:package_name_check.bzl", "gleam_package_name_check")  # buildifier: disable=bzl-visibility
 
 def _registers_validation_action_test_impl(ctx):
     env = analysistest.begin(ctx)

--- a/test/unit/package_name_check/package_name_check_test.bzl
+++ b/test/unit/package_name_check/package_name_check_test.bzl
@@ -4,8 +4,7 @@ gleam_package_name_check has no toolchain dependency, so its registered action c
 inspected directly via analysistest without needing a real Gleam/Erlang toolchain build.
 """
 
-load("@bazel_skylib//lib:analysistest.bzl", "analysistest")
-load("@bazel_skylib//lib:unittest.bzl", "asserts")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//gleam/private:package_name_check.bzl", "gleam_package_name_check")
 
 def _registers_validation_action_test_impl(ctx):

--- a/test/unit/version/BUILD.bazel
+++ b/test/unit/version/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":version_test.bzl", "version_test_suite")
+
+version_test_suite(name = "version_test_suite")

--- a/test/unit/version/version_test.bzl
+++ b/test/unit/version/version_test.bzl
@@ -1,7 +1,7 @@
 """Unit tests for gleam/private/version.bzl's parse_version."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//gleam/private:version.bzl", "parse_version")
+load("//gleam/private:version.bzl", "parse_version")  # buildifier: disable=bzl-visibility
 
 def _parses_simple_version_test_impl(ctx):
     env = unittest.begin(ctx)

--- a/test/unit/version/version_test.bzl
+++ b/test/unit/version/version_test.bzl
@@ -1,0 +1,47 @@
+"""Unit tests for gleam/private/version.bzl's parse_version."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//gleam/private:version.bzl", "parse_version")
+
+def _parses_simple_version_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, [1, 14, 0], parse_version("1.14.0"))
+    return unittest.end(env)
+
+parses_simple_version_test = unittest.make(_parses_simple_version_test_impl)
+
+def _parses_single_component_version_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, [2], parse_version("2"))
+    return unittest.end(env)
+
+parses_single_component_version_test = unittest.make(_parses_single_component_version_test_impl)
+
+def _strips_prerelease_suffix_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, [2, 0, 0], parse_version("2.0.0-rc1"))
+    return unittest.end(env)
+
+strips_prerelease_suffix_test = unittest.make(_strips_prerelease_suffix_test_impl)
+
+def _sorts_numerically_not_lexically_test_impl(ctx):
+    env = unittest.begin(ctx)
+    versions = ["1.9.0", "1.14.0", "1.2.0"]
+
+    # A lexical sort would put "1.9.0" first ("9" > "1" as characters); this is exactly the
+    # class of bug that would make gleam.toolchain's "highest version wins" selection pick the
+    # wrong one whenever a two-digit component is involved.
+    highest = sorted(versions, key = parse_version, reverse = True)[0]
+    asserts.equals(env, "1.14.0", highest)
+    return unittest.end(env)
+
+sorts_numerically_not_lexically_test = unittest.make(_sorts_numerically_not_lexically_test_impl)
+
+def version_test_suite(name):
+    unittest.suite(
+        name,
+        parses_simple_version_test,
+        parses_single_component_version_test,
+        strips_prerelease_suffix_test,
+        sorts_numerically_not_lexically_test,
+    )


### PR DESCRIPTION
## Summary

Phase 1 of closing this repo's testing gaps relative to mature rulesets (rules_rust/rules_go): every rule/module-extension helper was previously only exercised indirectly through full example builds, with no unit coverage and no test proving `gleam_test`/`gleam_format_test` actually detect failures.

- Extract the pure logic that regressed in `gleam_release` before PR #85 (choosing a runfiles-relative erl path vs. a PATH fallback) into `resolve_erl_invocation`, and unit test both branches directly (`test/unit/erlang_otp_tree/`) -- this is exactly the bug class an `analysistest` would have caught before any Docker CI run was needed.
- Extract `extensions.bzl`'s version-comparison helper into `gleam/private/version.bzl` so it's loadable and unit testable (`test/unit/version/`) -- module extension logic itself isn't `analysistest`-able.
- Add `analysistest` coverage for `gleam_package_name_check`'s registered action, and an `analysistest.expect_failure` test proving `find_erl_file`'s error message actually fires (`test/unit/package_name_check/`, `test/unit/erlang_otp_tree/`).
- Add unit tests for `manifest_toml` parsing edge cases (`test/unit/manifest_toml/`).
- Add `examples/expect_fail`: a deliberately-broken fixture (a failing `gleam_test` assertion, a misformatted `gleam_format_test` target) with a CI step asserting `bazel test` actually fails on both, since every other example in this repo only ever showed the happy path.

**Not included:** wiring `docs/rules.md`'s stardoc diff test into CI -- it's currently a deliberately-acknowledged stale placeholder (the file says so itself), so gating on it now would just break CI until someone with Bazel access regenerates it via `bazel run //docs:update`.

## Test plan

- [ ] CI green: `test/...` unit tests pass on both Bazel 8.x and 9.x
- [ ] `examples/expect_fail`'s intentionally-broken targets are confirmed to fail `bazel test`, and the CI step correctly reports that as a pass
- [ ] No regression in existing examples (`gleam_release`'s otp_tree branching still resolves the same way at runtime)
- [ ] pre-commit/buildifier checks pass on all new `.bzl`/`BUILD.bazel` files


---
_Generated by [Claude Code](https://claude.ai/code/session_011YhQ33xAXjUGpy7BxwcEhg)_