### PR TITLE
fix(deps): update module github.com/bazelbuild/bazel-gazelle to v0.52.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.12
 require github.com/bazelbuild/bazel-gazelle v0.52.0
 
 require (
-	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 // indirect
+	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2.0.20260716190442-a1b7ff21027b // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/muchq/rules_gleam
 
 go 1.24.12
 
-require github.com/bazelbuild/bazel-gazelle v0.51.3
+require github.com/bazelbuild/bazel-gazelle v0.52.0
 
 require (
 	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 h1:lSINS7DK4xjm0Z4CBd7onO63uIe6WUsEZ/0voExa+JY=
-github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
-github.com/bazelbuild/bazel-gazelle v0.51.3 h1:WtLCDPJTj06AWZizuN0SpkX8njjH1meOFgYbia6mD64=
-github.com/bazelbuild/bazel-gazelle v0.51.3/go.mod h1:AeYjUGaxXcMZ51CYHBT1YK3Qxb2yrJl77A8g7GF6d+g=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2.0.20260716190442-a1b7ff21027b h1:qCLcOGALKE8gdcQdyV++OPUMih/D6unb0QylMRcLsSc=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2.0.20260716190442-a1b7ff21027b/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
+github.com/bazelbuild/bazel-gazelle v0.52.0 h1:/pUFFocly6zTueng9Q0caJ7ZqcrGR2PBNXN1vLUNnqQ=
+github.com/bazelbuild/bazel-gazelle v0.52.0/go.mod h1:AeYjUGaxXcMZ51CYHBT1YK3Qxb2yrJl77A8g7GF6d+g=
 github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 h1:njQAmjTv/YHRm/0Lfv9DXHFZ4MdT2IA/RKHTnqZkgDw=
 github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
 github.com/bazelbuild/rules_go v0.59.0 h1:RLhOwYIqeMgBpKelHEWTfIPjA37so3oa/rX+/qqq/P4=


### PR DESCRIPTION
Supersedes #100 with the `go.sum` fix that its CI failure needs.

## Changes

- Bump `github.com/bazelbuild/bazel-gazelle` from v0.51.3 to v0.52.0 in `go.mod` (Renovate's original change from #100)
- Regenerate `go.sum`, which #100 was missing — this is what made the `pre-commit` job's `go vet` hook fail
- Pin `github.com/bazel-contrib/bazel-gazelle/v2` to the commit the v0.52.0 tag points at (`v2.0.0-2.0.20260716190442-a1b7ff21027b`): the published v0.52.0 v1 module imports `config` and `resolve` packages from the v2 module that don't exist in the tagged `v2.0.0-2` release its go.mod requires, so a plain `go mod tidy` can't resolve them

`MODULE.bazel` is intentionally left at gazelle 0.51.3 — the BCR `bazel_dep` is tracked separately by Renovate and Bazel CI is green on it.

Verified locally with `go build ./...` and `go vet ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWZGGFbMzDkuxFcuiuQRrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWZGGFbMzDkuxFcuiuQRrR)_